### PR TITLE
Changed package manager, fixed vite error and fixed wrong directory of relay in docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,18 @@ jobs:
         run: npm run build
       - name: Build success notification
         run: echo "✅ Build completed successfully"
+        
+      # Docker compose checks
+      - name: Docker Compose - dev environment
+        run: |
+          docker compose up --build -d
+          sleep 20
+          docker compose ps
+          docker compose down
+      - name: Docker Compose - relay-only environment
+        working-directory: relay
+        run: |
+          docker compose up --build -d
+          sleep 20
+          docker compose ps
+          docker compose down

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -1,17 +1,21 @@
 FROM node:22-alpine
 
-WORKDIR /app
+# Relay lives here
+WORKDIR /app/relay
 
-# Copy only relay-specific files first
-COPY package.json ./
-# Copy package-lock.json if it exists (optional for pnpm/yarn projects)
-COPY package-lock.json* ./
-RUN npm install --omit=dev --legacy-peer-deps
+# Copy relay-specific dependency files
+COPY relay/package.json relay/package-lock.json ./
 
-# Copy the rest of the relay files
-COPY . .
+# Install only production deps
+RUN npm ci --omit=dev
 
-# Expose ports
+# Copy the actual relay source
+COPY relay .
+
+# Persistent data directory (matches docker-compose)
+RUN mkdir -p /app/data
+
+# Expose relay ports
 # 4001: WebSocket
 # 4002: TCP
 # 4003: WebRTC 
@@ -19,8 +23,7 @@ COPY . .
 # 3000: HTTP API
 EXPOSE 4001 4002 4003 4006 3000
 
-# Set default environment variables
 ENV NODE_ENV=production
 
-# Run the enhanced relay server
+# Start relay correctly
 CMD ["node", "relay-enhanced.js"]

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,23 @@
 	import '../app.css';
 	// import favicon from '$lib/assets/favicon.svg';
 
+	// Register service worker for PWA offline support
+	import { registerSW } from 'virtual:pwa-register';
+
+	// Auto-update service worker when new version is available
+	if ('serviceWorker' in navigator) {
+		registerSW({
+			immediate: true,
+			onNeedRefresh() {
+				// New version available, will auto-update
+				console.log('New app version available, updating...');
+			},
+			onOfflineReady() {
+				console.log('App ready to work offline');
+			}
+		});
+	}
+
 	let { children } = $props();
 </script>
 


### PR DESCRIPTION
This PR fixes the broken Docker Compose setup in the root development environment and the relay container.

It also extends the existing CI workflow to spin up both docker-compose environments (root dev setup and relay-only setup) so regressions are caught automatically.

I’ve tested both compose setups locally.
