### PR TITLE
Add remote browser replication orchestration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.54.2-noble
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
     timeout-minutes: 15
     steps:
       - name: Checkout simple-todo

--- a/.github/workflows/remote-replication.yml
+++ b/.github/workflows/remote-replication.yml
@@ -1,0 +1,59 @@
+name: Remote browser replication
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_url:
+        description: Public main deployment URL
+        required: true
+        default: https://simple-todo.le-space.de
+      provider:
+        description: Second browser provider
+        required: true
+        type: choice
+        options:
+          - testingbot
+          - local
+        default: testingbot
+
+permissions:
+  contents: read
+
+jobs:
+  main-remote-replication:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      REMOTE_APP_URL: ${{ inputs.app_url }}
+      REMOTE_PROVIDER: ${{ inputs.provider }}
+      REQUIRE_PUBLIC_RELAY: 'true'
+      TESTINGBOT_KEY: ${{ secrets.TESTINGBOT_KEY }}
+      TESTINGBOT_SECRET: ${{ secrets.TESTINGBOT_SECRET }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install local Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run cross-network main replication
+        run: pnpm run test:e2e:remote:main
+
+      - name: Upload remote replication evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: remote-main-replication-${{ github.run_id }}
+          path: test-results/remote-main
+          if-no-files-found: warn
+          retention-days: 14

--- a/e2e/remote-main-local.spec.js
+++ b/e2e/remote-main-local.spec.js
@@ -1,0 +1,20 @@
+import { test, chromium } from '@playwright/test';
+import { runMainRemoteScenario } from './remote/main-scenario.mjs';
+
+test('provider-neutral main replication scenario works with separate local browsers', async ({
+	browser
+}) => {
+	test.setTimeout(240_000);
+	const browserB = await chromium.launch({ headless: true });
+
+	try {
+		await runMainRemoteScenario({
+			browserA: browser,
+			browserB,
+			appUrl: 'http://localhost:4173',
+			outputDir: 'test-results/remote-main-local'
+		});
+	} finally {
+		await browserB.close();
+	}
+});

--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -1,0 +1,81 @@
+import { expect } from '@playwright/test';
+
+const DEFAULT_TIMEOUT = 120_000;
+
+export class TodoBrowserAgent {
+	constructor(name, browser, appUrl, timeout = DEFAULT_TIMEOUT) {
+		this.name = name;
+		this.browser = browser;
+		this.appUrl = appUrl;
+		this.timeout = timeout;
+		this.context = null;
+		this.page = null;
+	}
+
+	async open() {
+		this.context = await this.browser.newContext();
+		this.page = await this.context.newPage();
+		await this.page.goto(this.appUrl, { waitUntil: 'domcontentloaded', timeout: this.timeout });
+
+		const modal = this.page.locator('div.fixed.inset-0.z-50');
+		await modal.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+		if (await modal.isVisible()) {
+			for (const checkbox of await modal.locator('input[type="checkbox"]').all()) {
+				await checkbox.check();
+			}
+			await this.page.getByRole('button', { name: 'Proceed to Test the App' }).click();
+		}
+
+		await expect(this.todoInput()).toBeEnabled({ timeout: this.timeout });
+		await this.page.waitForFunction(
+			() => typeof window.__simpleTodoDiagnostics?.getPeerId?.() === 'string',
+			undefined,
+			{ timeout: this.timeout }
+		);
+	}
+
+	async diagnostics() {
+		return this.page.evaluate(() => {
+			const diagnostics = window.__simpleTodoDiagnostics;
+			return {
+				peerId: diagnostics?.getPeerId?.() ?? null,
+				databaseAddress: diagnostics?.getDatabaseAddress?.() ?? null,
+				multiaddrs: diagnostics?.getMultiaddrs?.() ?? [],
+				connections: diagnostics?.getConnections?.() ?? [],
+				appStamp: document.querySelector('header p')?.textContent?.trim() ?? null,
+				userAgent: navigator.userAgent
+			};
+		});
+	}
+
+	async createTodo(text) {
+		await this.todoInput().fill(text);
+		await this.page.getByRole('button', { name: 'Add TODO' }).click();
+		await this.waitForTodo(text);
+	}
+
+	async waitForTodo(text) {
+		await expect(this.page.getByText(text, { exact: true })).toBeVisible({ timeout: this.timeout });
+	}
+
+	async screenshot(path) {
+		await this.page?.screenshot({ path, fullPage: true });
+	}
+
+	async setTestingBotStatus(passed, reason) {
+		if (!this.page) return;
+		const command = JSON.stringify({
+			action: 'setSessionStatus',
+			arguments: { passed, reason }
+		});
+		await this.page.evaluate(() => {}, `testingbot_executor: ${command}`);
+	}
+
+	todoInput() {
+		return this.page.getByPlaceholder('What needs to be done?');
+	}
+
+	async close() {
+		await this.context?.close();
+	}
+}

--- a/e2e/remote/main-scenario.mjs
+++ b/e2e/remote/main-scenario.mjs
@@ -1,0 +1,77 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { TodoBrowserAgent } from './agent.mjs';
+
+function hasPublicRelayConnection(diagnostics) {
+	return diagnostics.connections.some(({ remoteAddr }) =>
+		/\/dns4\/|\/dns6\/|\/ip4\/(?!127\.)|\/ip6\//.test(remoteAddr ?? '')
+	);
+}
+
+export async function runMainRemoteScenario({
+	browserA,
+	browserB,
+	appUrl,
+	outputDir,
+	remoteProvider = 'local'
+}) {
+	const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	const todoFromA = `remote-${runId}-from-a`;
+	const todoFromB = `remote-${runId}-from-b`;
+	const agentA = new TodoBrowserAgent('github-local', browserA, appUrl);
+	const agentB = new TodoBrowserAgent('testingbot-remote', browserB, appUrl);
+	const result = { runId, appUrl, agents: {}, replication: {}, passed: false };
+
+	await mkdir(outputDir, { recursive: true });
+
+	try {
+		await Promise.all([agentA.open(), agentB.open()]);
+		result.agents.a = await agentA.diagnostics();
+		result.agents.b = await agentB.diagnostics();
+
+		if (
+			!result.agents.a.databaseAddress ||
+			result.agents.a.databaseAddress !== result.agents.b.databaseAddress
+		) {
+			throw new Error(
+				`main agents opened different databases: ${result.agents.a.databaseAddress} vs ${result.agents.b.databaseAddress}`
+			);
+		}
+
+		if (process.env.REQUIRE_PUBLIC_RELAY === 'true') {
+			if (
+				!hasPublicRelayConnection(result.agents.a) ||
+				!hasPublicRelayConnection(result.agents.b)
+			) {
+				throw new Error('At least one browser has no observable public relay connection.');
+			}
+		}
+
+		const aToBStarted = Date.now();
+		await agentA.createTodo(todoFromA);
+		await agentB.waitForTodo(todoFromA);
+		result.replication.aToBMs = Date.now() - aToBStarted;
+
+		const bToAStarted = Date.now();
+		await agentB.createTodo(todoFromB);
+		await agentA.waitForTodo(todoFromB);
+		result.replication.bToAMs = Date.now() - bToAStarted;
+		result.passed = true;
+		if (remoteProvider === 'testingbot') {
+			await agentB.setTestingBotStatus(true, 'Bidirectional OrbitDB replication passed.');
+		}
+		return result;
+	} catch (error) {
+		result.error = error instanceof Error ? error.message : String(error);
+		if (remoteProvider === 'testingbot') {
+			await agentB.setTestingBotStatus(false, result.error).catch(() => {});
+		}
+		await Promise.allSettled([
+			agentA.screenshot(`${outputDir}/agent-a-failure.png`),
+			agentB.screenshot(`${outputDir}/agent-b-failure.png`)
+		]);
+		throw Object.assign(error instanceof Error ? error : new Error(result.error), { result });
+	} finally {
+		await writeFile(`${outputDir}/result.json`, `${JSON.stringify(result, null, 2)}\n`);
+		await Promise.allSettled([agentA.close(), agentB.close()]);
+	}
+}

--- a/e2e/remote/providers.mjs
+++ b/e2e/remote/providers.mjs
@@ -1,0 +1,32 @@
+import { chromium } from 'playwright';
+
+export async function createLocalBrowser() {
+	return chromium.launch({ headless: true });
+}
+
+export async function createTestingBotBrowser({ key, secret, buildName, testName }) {
+	if (!key || !secret) {
+		throw new Error(
+			'TESTINGBOT_KEY and TESTINGBOT_SECRET are required for the TestingBot provider.'
+		);
+	}
+
+	const capabilities = {
+		browserName: process.env.REMOTE_BROWSER || 'chrome',
+		browserVersion: process.env.REMOTE_BROWSER_VERSION || 'latest',
+		platform: process.env.REMOTE_PLATFORM || 'LINUX',
+		'tb:options': {
+			key,
+			secret,
+			build: buildName,
+			name: testName
+		}
+	};
+
+	return chromium.connect({
+		wsEndpoint: `wss://cloud.testingbot.com/playwright?capabilities=${encodeURIComponent(
+			JSON.stringify(capabilities)
+		)}`,
+		timeout: 120_000
+	});
+}

--- a/e2e/remote/run-main.mjs
+++ b/e2e/remote/run-main.mjs
@@ -1,0 +1,61 @@
+import { writeFile } from 'node:fs/promises';
+import { createLocalBrowser, createTestingBotBrowser } from './providers.mjs';
+import { runMainRemoteScenario } from './main-scenario.mjs';
+
+const appUrl = process.env.REMOTE_APP_URL || 'https://simple-todo.le-space.de';
+const provider = process.env.REMOTE_PROVIDER || 'local';
+const outputDir = process.env.REMOTE_OUTPUT_DIR || 'test-results/remote-main';
+const buildName = process.env.GITHUB_RUN_ID
+	? `simple-todo-${process.env.GITHUB_RUN_ID}`
+	: `simple-todo-${Date.now()}`;
+
+const browserA = await createLocalBrowser();
+const browserB =
+	provider === 'testingbot'
+		? await createTestingBotBrowser({
+				key: process.env.TESTINGBOT_KEY,
+				secret: process.env.TESTINGBOT_SECRET,
+				buildName,
+				testName: 'main cross-network OrbitDB replication'
+			})
+		: await createLocalBrowser();
+
+try {
+	const result = await runMainRemoteScenario({
+		browserA,
+		browserB,
+		appUrl,
+		outputDir,
+		remoteProvider: provider
+	});
+	console.log(JSON.stringify(result, null, 2));
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		await writeFile(
+			process.env.GITHUB_STEP_SUMMARY,
+			`## Remote OrbitDB replication — main\n\n` +
+				`**Result:** ✅ passed\n\n` +
+				`| Evidence | Agent A | Agent B |\n| --- | --- | --- |\n` +
+				`| Provider | GitHub/local Playwright | ${provider} |\n` +
+				`| Peer ID | \`${result.agents.a.peerId}\` | \`${result.agents.b.peerId}\` |\n` +
+				`| OrbitDB address | \`${result.agents.a.databaseAddress}\` | \`${result.agents.b.databaseAddress}\` |\n` +
+				`| A → B replication | ${result.replication.aToBMs} ms | observed |\n` +
+				`| B → A replication | observed | ${result.replication.bToAMs} ms |\n`,
+			{ flag: 'a' }
+		);
+	}
+} catch (error) {
+	const result = error?.result;
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		await writeFile(
+			process.env.GITHUB_STEP_SUMMARY,
+			`## Remote OrbitDB replication — main\n\n` +
+				`**Result:** ❌ failed\n\n` +
+				`**Reason:** ${result?.error ?? error?.message ?? String(error)}\n\n` +
+				`Detailed diagnostics and screenshots are available in the workflow artifact.\n`,
+			{ flag: 'a' }
+		);
+	}
+	throw error;
+} finally {
+	await Promise.allSettled([browserA.close(), browserB.close()]);
+}

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
 		"test:e2e": "playwright test",
 		"test:e2e:local-relay-src": "E2E_RELAY_CLI_PATH=/Users/nandi/orbitdb-relay/dist/cli.js E2E_RELAY_PINNING_PROOF=true playwright test e2e/collaboration.spec.js --project=chromium -g \"Relay-pinned\"",
 		"test:e2e:public-relay": "E2E_RELAY_MODE=public E2E_RELAY_PINNING_PROOF=true playwright test e2e/collaboration.spec.js --project=chromium",
+		"test:e2e:remote:main": "node e2e/remote/run-main.mjs",
 		"test:consent": "playwright test e2e/consent-screen.spec.js"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",
 		"@eslint/js": "^9.18.0",
-		"@playwright/test": "^1.54.2",
+		"@playwright/test": "^1.61.1",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
@@ -40,7 +41,7 @@
 		"globals": "^16.0.0",
 		"node-fetch": "^3.3.2",
 		"orbitdb-relay": "^0.9.3",
-		"playwright": "^1.54.2",
+		"playwright": "^1.61.1",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: ^9.18.0
         version: 9.32.0
       '@playwright/test':
-        specifier: ^1.54.2
-        version: 1.54.2
+        specifier: ^1.61.1
+        version: 1.61.1
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
         version: 3.0.8(@sveltejs/kit@2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))
@@ -150,7 +150,7 @@ importers:
         version: 4.1.11(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
       '@vitest/browser':
         specifier: ^3.2.3
-        version: 3.2.4(playwright@1.54.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)
+        version: 3.2.4(playwright@1.61.1)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
@@ -173,8 +173,8 @@ importers:
         specifier: ^0.9.3
         version: 0.9.3(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
       playwright:
-        specifier: ^1.54.2
-        version: 1.54.2
+        specifier: ^1.61.1
+        version: 1.61.1
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -1236,8 +1236,8 @@ packages:
     resolution: {integrity: sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==}
     engines: {node: '>=20.0.0'}
 
-  '@playwright/test@1.54.2':
-    resolution: {integrity: sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3830,13 +3830,13 @@ packages:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
 
-  playwright-core@1.54.2:
-    resolution: {integrity: sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.54.2:
-    resolution: {integrity: sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6816,9 +6816,9 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
-  '@playwright/test@1.54.2':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.54.2
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7231,7 +7231,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitest/browser@3.2.4(playwright@1.54.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(playwright@1.61.1)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
@@ -7243,7 +7243,7 @@ snapshots:
       vitest: 3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
       ws: 8.18.3
     optionalDependencies:
-      playwright: 1.54.2
+      playwright: 1.61.1
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -9802,11 +9802,11 @@ snapshots:
     dependencies:
       find-up: 5.0.0
 
-  playwright-core@1.54.2: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.54.2:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.54.2
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -10741,7 +10741,7 @@ snapshots:
 
   vitest-browser-svelte@0.1.0(@vitest/browser@3.2.4)(svelte@5.37.2)(vitest@3.2.4):
     dependencies:
-      '@vitest/browser': 3.2.4(playwright@1.54.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.61.1)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)
       svelte: 5.37.2
       vitest: 3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
 
@@ -10772,7 +10772,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1
-      '@vitest/browser': 3.2.4(playwright@1.54.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.61.1)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -119,6 +119,7 @@ export async function initializeP2P(options = /** @type {{ todoDbAddress?: strin
 
 		// Mark initialization as complete
 		initializationStore.set({ isInitializing: false, isInitialized: true, error: null });
+		installPublicDiagnostics();
 		installE2ETestHooks();
 		console.log('🎉 P2P initialization completed successfully!');
 	} catch (error) {
@@ -216,13 +217,10 @@ function createOrbitDBIdentityId() {
 	return `simple-todo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-function installE2ETestHooks() {
-	if (typeof window === 'undefined' || import.meta.env.VITE_E2E !== 'true') return;
-
-	/** @type {Window & typeof globalThis & { __simpleTodoE2E?: Record<string, unknown> }} */ (
-		window
-	).__simpleTodoE2E = {
+function getReadOnlyDiagnostics() {
+	return {
 		getPeerId: () => peerId,
+		getDatabaseAddress: () => get(todoDBAddressStore),
 		getMultiaddrs: () => {
 			const ownAddrs =
 				libp2p?.getMultiaddrs?.().map((/** @type {any} */ addr) => addr.toString()) ?? [];
@@ -232,6 +230,31 @@ function installE2ETestHooks() {
 					?.multiaddrs?.map((/** @type {any} */ addr) => addr.toString()) ?? [];
 			return Array.from(new Set([...ownAddrs, ...peerStoreAddrs]));
 		},
+		getConnections: () =>
+			libp2p?.getConnections?.().map((/** @type {any} */ connection) => ({
+				remotePeer: connection.remotePeer?.toString() ?? null,
+				remoteAddr: connection.remoteAddr?.toString() ?? null
+			})) ?? []
+	};
+}
+
+function installPublicDiagnostics() {
+	if (typeof window === 'undefined') return;
+
+	/** @type {Window & typeof globalThis & { __simpleTodoDiagnostics?: Record<string, unknown> }} */ (
+		window
+	).__simpleTodoDiagnostics = Object.freeze(getReadOnlyDiagnostics());
+}
+
+function installE2ETestHooks() {
+	if (typeof window === 'undefined' || import.meta.env.VITE_E2E !== 'true') return;
+
+	const diagnostics = getReadOnlyDiagnostics();
+
+	/** @type {Window & typeof globalThis & { __simpleTodoE2E?: Record<string, unknown> }} */ (
+		window
+	).__simpleTodoE2E = {
+		...diagnostics,
 		getConnectionCount: () => libp2p?.getConnections?.().length ?? 0,
 		getConnectedPeerIds: () =>
 			libp2p
@@ -256,11 +279,6 @@ function installE2ETestHooks() {
 		hasOrbitDBIdentity: async (/** @type {unknown} */ hash) =>
 			typeof hash === 'string' && Boolean(await orbitdb?.identities?.getIdentity?.(hash)),
 		publishOrbitDBIdentity,
-		getConnections: () =>
-			libp2p?.getConnections?.().map((/** @type {any} */ connection) => ({
-				remotePeer: connection.remotePeer?.toString() ?? null,
-				remoteAddr: connection.remoteAddr?.toString() ?? null
-			})) ?? [],
 		getWebRTCEnabled,
 		setWebRTCEnabled,
 		connectToMultiaddr
@@ -455,7 +473,11 @@ async function collectUint8Array(value) {
 		return concatUint8Arrays(chunks);
 	}
 
-	if (iterable && typeof iterable[Symbol.iterator] === 'function' && !(value instanceof Uint8Array)) {
+	if (
+		iterable &&
+		typeof iterable[Symbol.iterator] === 'function' &&
+		!(value instanceof Uint8Array)
+	) {
 		const chunks = [];
 		for (const chunk of iterable) {
 			chunks.push(toUint8Array(chunk));


### PR DESCRIPTION
## What changed

- adds a provider-neutral two-browser orchestration layer for remote OrbitDB replication tests
- adds local Playwright and TestingBot browser providers
- adds the `main` bidirectional replication scenario and local harness
- adds a manually dispatched GitHub Actions workflow with summaries and evidence artifacts
- exposes a frozen, read-only production diagnostics surface for peer/database/relay evidence
- aligns Playwright libraries and the CI browser image
- reports TestingBot session pass/fail using the official `testingbot_executor` pattern

## Why

The current E2E suite proves replication between local browser contexts. This prepares a cross-provider test where browser A runs on GitHub Actions and browser B runs on TestingBot against the deployed PWA and public relay.

## Validation

- `pnpm run check`
- `pnpm run test:unit` — 3 passed
- provider-neutral local remote harness — passed
- existing main database collaboration E2E — passed
- combined Playwright run — 2 passed

## Remaining external setup

- obtain TestingBot OSS access
- add `TESTINGBOT_KEY` and `TESTINGBOT_SECRET` repository secrets
- run and verify the first real GitHub Actions ↔ TestingBot session

Tracks #3.

