### PR TITLE
Use credit-paid Aleph site STORE publisher

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Install isolated Aleph deploy tooling
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.20
+        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.21
 
       - name: Publish to Aleph IPFS
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -147,7 +147,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Install isolated Aleph deploy tooling
-        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.20
+        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.21
 
       - name: Link custom domain
         if: inputs.domain != '' || env.ALEPH_MAIN_SITE_DOMAIN != ''


### PR DESCRIPTION
Uses @le-space/node@0.6.21, which adds the missing payment: { type: credit } field to website STORE content after live run 29154962091 proved that the CID was available but the payment-less STORE stayed pending. Related: NiKrause/relay-button#20 and NiKrause/relay-button#22.