### PR TITLE
Use authenticated CAR site publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,7 @@ jobs:
     needs: e2e
     runs-on: ubuntu-latest
     outputs:
+      ipfs_cid: ${{ steps.publish.outputs.ipfs_cid }}
       ipfs_cid_v0: ${{ steps.publish.outputs.ipfs_cid_v0 }}
       ipfs_cid_v1: ${{ steps.publish.outputs.ipfs_cid_v1 }}
       item_hash: ${{ steps.publish.outputs.item_hash }}
@@ -108,7 +109,7 @@ jobs:
 
       - name: Install isolated Aleph deploy tooling
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.21
+        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.22
 
       - name: Publish to Aleph IPFS
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -117,7 +118,7 @@ jobs:
           ALEPH_VM_MODE: site-publish
           ALEPH_SITE_DIRECTORY: ${{ github.workspace }}/build
           ALEPH_SITE_PIN: 'true'
-          ALEPH_SITE_REF: simple-todo
+          ALEPH_SITE_NAME: simple-todo
           ALEPH_SITE_CHANNEL: ALEPH-CLOUDSOLUTIONS
           ALEPH_PRIVATE_KEY: ${{ secrets.ALEPH_PRIVATE_KEY }}
         run: node --input-type=module -e "import('/tmp/le-space-deployer/node_modules/@le-space/node/index.js').then((m) => m.runSiteMode())"
@@ -147,7 +148,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Install isolated Aleph deploy tooling
-        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.21
+        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.22
 
       - name: Link custom domain
         if: inputs.domain != '' || env.ALEPH_MAIN_SITE_DOMAIN != ''
@@ -155,6 +156,7 @@ jobs:
         env:
           ALEPH_VM_MODE: site-domain-link
           ALEPH_SITE_ITEM_HASH: ${{ needs.build-and-deploy.outputs.item_hash }}
+          ALEPH_SITE_IPFS_CID: ${{ needs.build-and-deploy.outputs.ipfs_cid }}
           ALEPH_SITE_IPFS_CID_V0: ${{ needs.build-and-deploy.outputs.ipfs_cid_v0 }}
           ALEPH_SITE_DOMAIN: ${{ inputs.domain || env.ALEPH_MAIN_SITE_DOMAIN }}
           ALEPH_SITE_DOMAIN_CATCH_ALL_PATH: /index.html


### PR DESCRIPTION
Updates the Aleph deployment tooling to @le-space/node 0.6.22 and adopts the aleph-rs-compatible authenticated CAR upload flow. Carries the exact CIDv1 root into domain verification and publishes the versioned simple-todo website aggregate.\n\nLocal verification:\n- Unit tests: 3/3 passed\n- Deployment Chromium collaboration E2E: 1/1 passed\n- Full local Playwright run: Chromium passed; Firefox/WebKit were unavailable locally (browser executables not installed)