### PR TITLE
Wait for relay connections in remote E2E

### DIFF
--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -48,6 +48,19 @@ export class TodoBrowserAgent {
 		});
 	}
 
+	async waitForPublicRelayConnection() {
+		await this.page.waitForFunction(
+			() =>
+				(window.__simpleTodoDiagnostics?.getConnections?.() ?? []).some(({ remoteAddr }) =>
+					/\/dns4\/|\/dns6\/|\/ip4\/(?!127\.)|\/ip6\//.test(remoteAddr ?? '')
+				),
+			undefined,
+			{ timeout: this.timeout, polling: 1_000 }
+		);
+
+		return this.diagnostics();
+	}
+
 	async createTodo(text) {
 		await this.todoInput().fill(text);
 		await this.page.getByRole('button', { name: 'Add TODO' }).click();

--- a/e2e/remote/main-scenario.mjs
+++ b/e2e/remote/main-scenario.mjs
@@ -25,6 +25,12 @@ export async function runMainRemoteScenario({
 
 	try {
 		await Promise.all([agentA.open(), agentB.open()]);
+		if (process.env.REQUIRE_PUBLIC_RELAY === 'true') {
+			await Promise.all([
+				agentA.waitForPublicRelayConnection(),
+				agentB.waitForPublicRelayConnection()
+			]);
+		}
 		result.agents.a = await agentA.diagnostics();
 		result.agents.b = await agentB.diagnostics();
 
@@ -61,6 +67,12 @@ export async function runMainRemoteScenario({
 		}
 		return result;
 	} catch (error) {
+		const [diagnosticsA, diagnosticsB] = await Promise.allSettled([
+			agentA.diagnostics(),
+			agentB.diagnostics()
+		]);
+		if (diagnosticsA.status === 'fulfilled') result.agents.a = diagnosticsA.value;
+		if (diagnosticsB.status === 'fulfilled') result.agents.b = diagnosticsB.value;
 		result.error = error instanceof Error ? error.message : String(error);
 		if (remoteProvider === 'testingbot') {
 			await agentB.setTestingBotStatus(false, result.error).catch(() => {});


### PR DESCRIPTION
Fixes a timing false positive in the distributed replication test. The test previously sampled libp2p connections immediately after app initialisation, while failure screenshots and TestingBot video already showed two connected peers moments later.

The agents now poll for an observable public relay connection before taking the evidence snapshot or attempting replication, and capture final diagnostics if the wait times out.

Verified locally against https://simple-todo.le-space.de with two isolated browsers:
- both browsers observed public relay connections
- A to B replication: 894 ms\n- B to A replication: 889 ms\n- scenario passed