### PR TITLE
Link remote E2E screenshots and TestingBot video

### DIFF
--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -84,6 +84,12 @@ export class TodoBrowserAgent {
 		await this.page.evaluate(() => {}, `testingbot_executor: ${command}`);
 	}
 
+	async getTestingBotSessionDetails() {
+		if (!this.page) return null;
+		const command = JSON.stringify({ action: 'getSessionDetails' });
+		return this.page.evaluate(() => {}, `testingbot_executor: ${command}`);
+	}
+
 	todoInput() {
 		return this.page.getByPlaceholder('What needs to be done?');
 	}

--- a/e2e/remote/main-scenario.mjs
+++ b/e2e/remote/main-scenario.mjs
@@ -19,7 +19,7 @@ export async function runMainRemoteScenario({
 	const todoFromB = `remote-${runId}-from-b`;
 	const agentA = new TodoBrowserAgent('github-local', browserA, appUrl);
 	const agentB = new TodoBrowserAgent('testingbot-remote', browserB, appUrl);
-	const result = { runId, appUrl, agents: {}, replication: {}, passed: false };
+	const result = { runId, appUrl, agents: {}, replication: {}, evidence: {}, passed: false };
 
 	await mkdir(outputDir, { recursive: true });
 
@@ -64,7 +64,13 @@ export async function runMainRemoteScenario({
 		result.passed = true;
 		if (remoteProvider === 'testingbot') {
 			await agentB.setTestingBotStatus(true, 'Bidirectional OrbitDB replication passed.');
+			result.evidence.testingBot = await agentB.getTestingBotSessionDetails();
 		}
+		await Promise.all([
+			agentA.screenshot(`${outputDir}/agent-a-success.png`),
+			agentB.screenshot(`${outputDir}/agent-b-success.png`)
+		]);
+		result.evidence.screenshots = ['agent-a-success.png', 'agent-b-success.png'];
 		return result;
 	} catch (error) {
 		const [diagnosticsA, diagnosticsB] = await Promise.allSettled([

--- a/e2e/remote/run-main.mjs
+++ b/e2e/remote/run-main.mjs
@@ -1,4 +1,5 @@
 import { writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { createLocalBrowser, createTestingBotBrowser } from './providers.mjs';
 import { runMainRemoteScenario } from './main-scenario.mjs';
 
@@ -28,6 +29,22 @@ try {
 		outputDir,
 		remoteProvider: provider
 	});
+	const githubRunUrl = process.env.GITHUB_RUN_ID
+		? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+		: null;
+	const githubArtifactsUrl = githubRunUrl ? `${githubRunUrl}#artifacts` : null;
+	const testingBotSessionId = result.evidence.testingBot?.sessionId ?? null;
+	const testingBotShareUrl =
+		testingBotSessionId && process.env.TESTINGBOT_KEY && process.env.TESTINGBOT_SECRET
+			? `https://testingbot.com/tests/${testingBotSessionId}?auth=${createHash('md5')
+					.update(
+						`${process.env.TESTINGBOT_KEY}:${process.env.TESTINGBOT_SECRET}:${testingBotSessionId}`
+					)
+					.digest('hex')}`
+			: null;
+	result.evidence.githubRunUrl = githubRunUrl;
+	result.evidence.githubArtifactsUrl = githubArtifactsUrl;
+	result.evidence.testingBotShareUrl = testingBotShareUrl;
 	console.log(JSON.stringify(result, null, 2));
 	if (process.env.GITHUB_STEP_SUMMARY) {
 		await writeFile(
@@ -39,7 +56,13 @@ try {
 				`| Peer ID | \`${result.agents.a.peerId}\` | \`${result.agents.b.peerId}\` |\n` +
 				`| OrbitDB address | \`${result.agents.a.databaseAddress}\` | \`${result.agents.b.databaseAddress}\` |\n` +
 				`| A → B replication | ${result.replication.aToBMs} ms | observed |\n` +
-				`| B → A replication | observed | ${result.replication.bToAMs} ms |\n`,
+				`| B → A replication | observed | ${result.replication.bToAMs} ms |\n\n` +
+				`### Evidence\n\n` +
+				(githubRunUrl ? `- [GitHub workflow run](${githubRunUrl})\n` : '') +
+				(githubArtifactsUrl
+					? `- [Success screenshots and result JSON](${githubArtifactsUrl})\n`
+					: '') +
+				(testingBotShareUrl ? `- [TestingBot session and video](${testingBotShareUrl})\n` : ''),
 			{ flag: 'a' }
 		);
 	}


### PR DESCRIPTION
Adds durable evidence links to the remote replication workflow summary.\n\n- captures success screenshots from the GitHub and TestingBot browsers\n- uploads screenshots and result JSON through the existing artifact step\n- retrieves the TestingBot Playwright session ID\n- creates TestingBot's authenticated share link to the session detail/video\n- links the GitHub run and artifact section from the summary\n\nLocal verification:\n- unit tests: 3/3 passed\n- public two-browser remote scenario: passed\n- success screenshots produced for both agents\n- A to B: 30245 ms; B to A: 307 ms