### PR TITLE
Consolidate collab01 CAR deployment and remote E2E

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,9 +75,12 @@ jobs:
     needs: e2e
     runs-on: ubuntu-latest
     outputs:
+      ipfs_cid: ${{ steps.publish.outputs.ipfs_cid }}
       ipfs_cid_v0: ${{ steps.publish.outputs.ipfs_cid_v0 }}
       ipfs_cid_v1: ${{ steps.publish.outputs.ipfs_cid_v1 }}
       item_hash: ${{ steps.publish.outputs.item_hash }}
+      store_status: ${{ steps.publish.outputs.store_status }}
+      store_processed: ${{ steps.publish.outputs.store_processed }}
       url: ${{ steps.publish.outputs.url }}
     steps:
       - name: Checkout collab01
@@ -103,7 +106,7 @@ jobs:
 
       - name: Install isolated Aleph deploy tooling
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.11
+        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.22
 
       - name: Publish to Aleph IPFS
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -112,7 +115,7 @@ jobs:
           ALEPH_VM_MODE: site-publish
           ALEPH_SITE_DIRECTORY: ${{ github.workspace }}/build
           ALEPH_SITE_PIN: 'true'
-          ALEPH_SITE_REF: simple-todo-collab01
+          ALEPH_SITE_NAME: simple-todo-collab01
           ALEPH_SITE_CHANNEL: ALEPH-CLOUDSOLUTIONS
           ALEPH_PRIVATE_KEY: ${{ secrets.ALEPH_PRIVATE_KEY }}
         run: node --input-type=module -e "import('/tmp/le-space-deployer/node_modules/@le-space/node/index.js').then((m) => m.runSiteMode())"
@@ -121,7 +124,8 @@ jobs:
     needs: build-and-deploy
     if: >-
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-      needs.build-and-deploy.outputs.item_hash != ''
+      needs.build-and-deploy.outputs.item_hash != '' &&
+      needs.build-and-deploy.outputs.store_processed == 'true'
     runs-on: ubuntu-latest
     env:
       ALEPH_COLLAB01_SITE_DOMAIN: collab01.le-space.de
@@ -141,7 +145,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Install isolated Aleph deploy tooling
-        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.11
+        run: npm install --prefix /tmp/le-space-deployer @le-space/node@0.6.22
 
       - name: Link custom domain
         if: inputs.domain != '' || env.ALEPH_COLLAB01_SITE_DOMAIN != ''
@@ -149,6 +153,8 @@ jobs:
         env:
           ALEPH_VM_MODE: site-domain-link
           ALEPH_SITE_ITEM_HASH: ${{ needs.build-and-deploy.outputs.item_hash }}
+          ALEPH_SITE_IPFS_CID: ${{ needs.build-and-deploy.outputs.ipfs_cid }}
+          ALEPH_SITE_IPFS_CID_V0: ${{ needs.build-and-deploy.outputs.ipfs_cid_v0 }}
           ALEPH_SITE_DOMAIN: ${{ inputs.domain || env.ALEPH_COLLAB01_SITE_DOMAIN }}
           ALEPH_SITE_DOMAIN_CATCH_ALL_PATH: /index.html
           ALEPH_PRIVATE_KEY: ${{ secrets.ALEPH_PRIVATE_KEY }}

--- a/.github/workflows/remote-replication.yml
+++ b/.github/workflows/remote-replication.yml
@@ -1,0 +1,59 @@
+name: Remote browser replication
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_url:
+        description: Public collab01 deployment URL
+        required: true
+        default: https://collab01.le-space.de
+      provider:
+        description: Second browser provider
+        required: true
+        type: choice
+        options:
+          - testingbot
+          - local
+        default: testingbot
+
+permissions:
+  contents: read
+
+jobs:
+  collab01-remote-replication:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      REMOTE_APP_URL: ${{ inputs.app_url }}
+      REMOTE_PROVIDER: ${{ inputs.provider }}
+      REQUIRE_PUBLIC_RELAY: 'true'
+      TESTINGBOT_KEY: ${{ secrets.TESTINGBOT_KEY }}
+      TESTINGBOT_SECRET: ${{ secrets.TESTINGBOT_SECRET }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install local Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run cross-network collab01 replication
+        run: pnpm run test:e2e:remote:collab01
+
+      - name: Upload remote replication evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: remote-collab01-replication-${{ github.run_id }}
+          path: test-results/remote-collab01
+          if-no-files-found: warn
+          retention-days: 14

--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -1,0 +1,153 @@
+import { expect } from '@playwright/test';
+
+const DEFAULT_TIMEOUT = 120_000;
+
+export class TodoBrowserAgent {
+	constructor(name, browser, appUrl, timeout = DEFAULT_TIMEOUT) {
+		this.name = name;
+		this.browser = browser;
+		this.appUrl = appUrl;
+		this.timeout = timeout;
+		this.context = null;
+		this.page = null;
+	}
+
+	async open() {
+		this.context = await this.browser.newContext();
+		this.page = await this.context.newPage();
+		await this.page.goto(this.appUrl, { waitUntil: 'domcontentloaded', timeout: this.timeout });
+
+		const modal = this.page.locator('div.fixed.inset-0.z-50');
+		await modal.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+		if (await modal.isVisible()) {
+			for (const checkbox of await modal.locator('input[type="checkbox"]').all()) {
+				await checkbox.check();
+			}
+			await this.page.getByRole('button', { name: 'Proceed to Test the App' }).click();
+		}
+
+		await expect(this.todoInput()).toBeEnabled({ timeout: this.timeout });
+		await this.page.waitForFunction(
+			() => typeof window.__simpleTodoDiagnostics?.getPeerId?.() === 'string',
+			undefined,
+			{ timeout: this.timeout }
+		);
+	}
+
+	async diagnostics() {
+		const diagnostics = await this.page.evaluate(() => {
+			const diagnostics = window.__simpleTodoDiagnostics;
+			return {
+				peerId: diagnostics?.getPeerId?.() ?? null,
+				databaseAddress:
+					window.getTodoDatabaseAddress?.() ?? diagnostics?.getDatabaseAddress?.() ?? null,
+				multiaddrs: diagnostics?.getMultiaddrs?.() ?? [],
+				connections: diagnostics?.getConnections?.() ?? [],
+				appStamp: document.querySelector('header p')?.textContent?.trim() ?? null,
+				userAgent: navigator.userAgent
+			};
+		});
+		const visibleDatabaseAddress = await this.page
+			.getByTestId('load-todo-db-input')
+			.inputValue()
+			.catch(() => '');
+		return {
+			...diagnostics,
+			databaseAddress: visibleDatabaseAddress || diagnostics.databaseAddress
+		};
+	}
+
+	async waitForPublicRelayConnection() {
+		await this.page.waitForFunction(
+			() =>
+				(window.__simpleTodoDiagnostics?.getConnections?.() ?? []).some(({ remoteAddr }) =>
+					/\/dns4\/|\/dns6\/|\/ip4\/(?!127\.)|\/ip6\//.test(remoteAddr ?? '')
+				),
+			undefined,
+			{ timeout: this.timeout, polling: 1_000 }
+		);
+
+		return this.diagnostics();
+	}
+
+	async createTodo(text) {
+		await this.todoInput().fill(text);
+		await this.page.getByRole('button', { name: 'Add TODO' }).click();
+		await this.waitForTodo(text);
+	}
+
+	async openDatabase(address) {
+		const input = this.page.getByTestId('load-todo-db-input');
+		await input.fill(address);
+		await this.page.getByTestId('load-todo-db-button').click();
+		await expect(this.page.getByText('Todo DB loaded', { exact: true })).toBeVisible({
+			timeout: this.timeout
+		});
+		await expect(input).toHaveValue(address, { timeout: this.timeout });
+	}
+
+	async announceDatabaseEntries() {
+		await this.page.evaluate(async () => {
+			if (typeof window.announceTodoDatabaseEntries !== 'function') {
+				throw new Error('Todo database entry announcement hook is unavailable.');
+			}
+			await window.announceTodoDatabaseEntries({ attempts: 3, delayMs: 3_000 });
+		});
+	}
+
+	async publishOrbitDBIdentity() {
+		await this.page.evaluate(async () => {
+			const publishIdentity = window.__simpleTodoDiagnostics?.publishOrbitDBIdentity;
+			if (typeof publishIdentity !== 'function') {
+				throw new Error('OrbitDB identity publication hook is unavailable.');
+			}
+			await publishIdentity();
+		});
+	}
+
+	async getOrbitDBIdentity() {
+		return this.page.evaluate(
+			() => window.__simpleTodoDiagnostics?.getOrbitDBIdentity?.() ?? null
+		);
+	}
+
+	async waitForOrbitDBIdentity(hash) {
+		await this.page.waitForFunction(
+			async (identityHash) =>
+				Boolean(await window.__simpleTodoDiagnostics?.hasOrbitDBIdentity?.(identityHash)),
+			hash,
+			{ timeout: this.timeout, polling: 1_000 }
+		);
+	}
+
+	async waitForTodo(text) {
+		await expect(this.page.getByText(text, { exact: true })).toBeVisible({ timeout: this.timeout });
+	}
+
+	async screenshot(path) {
+		await this.page?.screenshot({ path, fullPage: true });
+	}
+
+	async setTestingBotStatus(passed, reason) {
+		if (!this.page) return;
+		const command = JSON.stringify({
+			action: 'setSessionStatus',
+			arguments: { passed, reason }
+		});
+		await this.page.evaluate(() => {}, `testingbot_executor: ${command}`);
+	}
+
+	async getTestingBotSessionDetails() {
+		if (!this.page) return null;
+		const command = JSON.stringify({ action: 'getSessionDetails' });
+		return this.page.evaluate(() => {}, `testingbot_executor: ${command}`);
+	}
+
+	todoInput() {
+		return this.page.getByPlaceholder('What needs to be done?');
+	}
+
+	async close() {
+		await this.context?.close();
+	}
+}

--- a/e2e/remote/collab01-scenario.mjs
+++ b/e2e/remote/collab01-scenario.mjs
@@ -1,0 +1,120 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { TodoBrowserAgent } from './agent.mjs';
+
+function hasPublicRelayConnection(diagnostics) {
+	return diagnostics.connections.some(({ remoteAddr }) =>
+		/\/dns4\/|\/dns6\/|\/ip4\/(?!127\.)|\/ip6\//.test(remoteAddr ?? '')
+	);
+}
+
+export async function runCollab01RemoteScenario({
+	browserA,
+	browserB,
+	appUrl,
+	outputDir,
+	remoteProvider = 'local'
+}) {
+	const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	const todoFromA = `remote-${runId}-from-a`;
+	const todoFromB = `remote-${runId}-from-b`;
+	const agentA = new TodoBrowserAgent('github-local', browserA, appUrl);
+	const agentB = new TodoBrowserAgent('testingbot-remote', browserB, appUrl);
+	const result = { runId, appUrl, agents: {}, replication: {}, evidence: {}, passed: false };
+
+	await mkdir(outputDir, { recursive: true });
+
+	try {
+		await Promise.all([agentA.open(), agentB.open()]);
+		if (process.env.REQUIRE_PUBLIC_RELAY === 'true') {
+			await Promise.all([
+				agentA.waitForPublicRelayConnection(),
+				agentB.waitForPublicRelayConnection()
+			]);
+		}
+		result.agents.a = await agentA.diagnostics();
+		result.agents.b = await agentB.diagnostics();
+
+		if (!result.agents.a.databaseAddress || !result.agents.b.databaseAddress) {
+			throw new Error('At least one collab01 agent did not expose its initial database address.');
+		}
+		if (result.agents.a.databaseAddress === result.agents.b.databaseAddress) {
+			throw new Error(
+				`collab01 agents unexpectedly opened the same initial database: ${result.agents.a.databaseAddress}`
+			);
+		}
+
+		if (process.env.REQUIRE_PUBLIC_RELAY === 'true') {
+			if (
+				!hasPublicRelayConnection(result.agents.a) ||
+				!hasPublicRelayConnection(result.agents.b)
+			) {
+				throw new Error('At least one browser has no observable public relay connection.');
+			}
+		}
+
+		result.databaseExchange = {
+			source: 'agent-a',
+			address: result.agents.a.databaseAddress,
+			target: 'agent-b'
+		};
+		await agentB.openDatabase(result.agents.a.databaseAddress);
+		result.agents.b = await agentB.diagnostics();
+		if (result.agents.b.databaseAddress !== result.agents.a.databaseAddress) {
+			throw new Error("Agent B did not open Agent A's database through the collab01 UI.");
+		}
+		await Promise.all([agentA.publishOrbitDBIdentity(), agentB.publishOrbitDBIdentity()]);
+		const [identityA, identityB] = await Promise.all([
+			agentA.getOrbitDBIdentity(),
+			agentB.getOrbitDBIdentity()
+		]);
+		await Promise.all([
+			agentA.waitForOrbitDBIdentity(identityB?.hash),
+			agentB.waitForOrbitDBIdentity(identityA?.hash)
+		]);
+
+		const bToAStarted = Date.now();
+		await agentB.createTodo(todoFromB);
+		await agentB.announceDatabaseEntries();
+		await agentA.waitForTodo(todoFromB);
+		result.replication.bToAMs = Date.now() - bToAStarted;
+
+		const aToBStarted = Date.now();
+		await agentA.createTodo(todoFromA);
+		await agentA.announceDatabaseEntries();
+		await agentB.waitForTodo(todoFromA);
+		result.replication.aToBMs = Date.now() - aToBStarted;
+		result.passed = true;
+		if (remoteProvider === 'testingbot') {
+			await agentB.setTestingBotStatus(
+				true,
+				'collab01 address exchange and bidirectional OrbitDB replication passed.'
+			);
+			result.evidence.testingBot = await agentB.getTestingBotSessionDetails();
+		}
+		await Promise.all([
+			agentA.screenshot(`${outputDir}/agent-a-success.png`),
+			agentB.screenshot(`${outputDir}/agent-b-success.png`)
+		]);
+		result.evidence.screenshots = ['agent-a-success.png', 'agent-b-success.png'];
+		return result;
+	} catch (error) {
+		const [diagnosticsA, diagnosticsB] = await Promise.allSettled([
+			agentA.diagnostics(),
+			agentB.diagnostics()
+		]);
+		if (diagnosticsA.status === 'fulfilled') result.agents.a = diagnosticsA.value;
+		if (diagnosticsB.status === 'fulfilled') result.agents.b = diagnosticsB.value;
+		result.error = error instanceof Error ? error.message : String(error);
+		if (remoteProvider === 'testingbot') {
+			await agentB.setTestingBotStatus(false, result.error).catch(() => {});
+		}
+		await Promise.allSettled([
+			agentA.screenshot(`${outputDir}/agent-a-failure.png`),
+			agentB.screenshot(`${outputDir}/agent-b-failure.png`)
+		]);
+		throw Object.assign(error instanceof Error ? error : new Error(result.error), { result });
+	} finally {
+		await writeFile(`${outputDir}/result.json`, `${JSON.stringify(result, null, 2)}\n`);
+		await Promise.allSettled([agentA.close(), agentB.close()]);
+	}
+}

--- a/e2e/remote/providers.mjs
+++ b/e2e/remote/providers.mjs
@@ -1,0 +1,32 @@
+import { chromium } from 'playwright';
+
+export async function createLocalBrowser() {
+	return chromium.launch({ headless: true });
+}
+
+export async function createTestingBotBrowser({ key, secret, buildName, testName }) {
+	if (!key || !secret) {
+		throw new Error(
+			'TESTINGBOT_KEY and TESTINGBOT_SECRET are required for the TestingBot provider.'
+		);
+	}
+
+	const capabilities = {
+		browserName: process.env.REMOTE_BROWSER || 'chrome',
+		browserVersion: process.env.REMOTE_BROWSER_VERSION || 'latest',
+		platform: process.env.REMOTE_PLATFORM || 'LINUX',
+		'tb:options': {
+			key,
+			secret,
+			build: buildName,
+			name: testName
+		}
+	};
+
+	return chromium.connect({
+		wsEndpoint: `wss://cloud.testingbot.com/playwright?capabilities=${encodeURIComponent(
+			JSON.stringify(capabilities)
+		)}`,
+		timeout: 120_000
+	});
+}

--- a/e2e/remote/run-collab01.mjs
+++ b/e2e/remote/run-collab01.mjs
@@ -1,0 +1,86 @@
+import { writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { createLocalBrowser, createTestingBotBrowser } from './providers.mjs';
+import { runCollab01RemoteScenario } from './collab01-scenario.mjs';
+
+const appUrl = process.env.REMOTE_APP_URL || 'https://collab01.le-space.de';
+const provider = process.env.REMOTE_PROVIDER || 'local';
+const outputDir = process.env.REMOTE_OUTPUT_DIR || 'test-results/remote-collab01';
+const buildName = process.env.GITHUB_RUN_ID
+	? `simple-todo-collab01-${process.env.GITHUB_RUN_ID}`
+	: `simple-todo-collab01-${Date.now()}`;
+
+const browserA = await createLocalBrowser();
+const browserB =
+	provider === 'testingbot'
+		? await createTestingBotBrowser({
+				key: process.env.TESTINGBOT_KEY,
+				secret: process.env.TESTINGBOT_SECRET,
+				buildName,
+				testName: 'collab01 cross-network OrbitDB replication'
+			})
+		: await createLocalBrowser();
+
+try {
+	const result = await runCollab01RemoteScenario({
+		browserA,
+		browserB,
+		appUrl,
+		outputDir,
+		remoteProvider: provider
+	});
+	const githubRunUrl = process.env.GITHUB_RUN_ID
+		? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+		: null;
+	const githubArtifactsUrl = githubRunUrl ? `${githubRunUrl}#artifacts` : null;
+	const testingBotSessionId = result.evidence.testingBot?.sessionId ?? null;
+	const testingBotShareUrl =
+		testingBotSessionId && process.env.TESTINGBOT_KEY && process.env.TESTINGBOT_SECRET
+			? `https://testingbot.com/tests/${testingBotSessionId}?auth=${createHash('md5')
+					.update(
+						`${process.env.TESTINGBOT_KEY}:${process.env.TESTINGBOT_SECRET}:${testingBotSessionId}`
+					)
+					.digest('hex')}`
+			: null;
+	result.evidence.githubRunUrl = githubRunUrl;
+	result.evidence.githubArtifactsUrl = githubArtifactsUrl;
+	result.evidence.testingBotShareUrl = testingBotShareUrl;
+	console.log(JSON.stringify(result, null, 2));
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		await writeFile(
+			process.env.GITHUB_STEP_SUMMARY,
+			`## Remote OrbitDB replication — collab01\n\n` +
+				`**Result:** ✅ passed\n\n` +
+				`| Evidence | Agent A | Agent B |\n| --- | --- | --- |\n` +
+				`| Provider | GitHub/local Playwright | ${provider} |\n` +
+				`| Peer ID | \`${result.agents.a.peerId}\` | \`${result.agents.b.peerId}\` |\n` +
+				`| Initial OrbitDB address | \`${result.databaseExchange.address}\` | separate initial database |\n` +
+				`| Address exchange | exposed through coordinator control state | opened Agent A database through collab01 UI |\n` +
+				`| Shared OrbitDB address | \`${result.agents.a.databaseAddress}\` | \`${result.agents.b.databaseAddress}\` |\n` +
+				`| A → B replication | ${result.replication.aToBMs} ms | observed |\n` +
+				`| B → A replication | observed | ${result.replication.bToAMs} ms |\n\n` +
+				`### Evidence\n\n` +
+				(githubRunUrl ? `- [GitHub workflow run](${githubRunUrl})\n` : '') +
+				(githubArtifactsUrl
+					? `- [Success screenshots and result JSON](${githubArtifactsUrl})\n`
+					: '') +
+				(testingBotShareUrl ? `- [TestingBot session and video](${testingBotShareUrl})\n` : ''),
+			{ flag: 'a' }
+		);
+	}
+} catch (error) {
+	const result = error?.result;
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		await writeFile(
+			process.env.GITHUB_STEP_SUMMARY,
+			`## Remote OrbitDB replication — collab01\n\n` +
+				`**Result:** ❌ failed\n\n` +
+				`**Reason:** ${result?.error ?? error?.message ?? String(error)}\n\n` +
+				`Detailed diagnostics and screenshots are available in the workflow artifact.\n`,
+			{ flag: 'a' }
+		);
+	}
+	throw error;
+} finally {
+	await Promise.allSettled([browserA.close(), browserB.close()]);
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"test:unit": "vitest --run",
 		"test": "pnpm run test:unit && pnpm run test:e2e",
 		"test:e2e": "playwright test",
+		"test:e2e:remote:collab01": "node e2e/remote/run-collab01.mjs",
 		"test:e2e:local-relay-src": "E2E_RELAY_CLI_PATH=/Users/nandi/orbitdb-relay/dist/cli.js E2E_RELAY_PINNING_PROOF=true playwright test e2e/collaboration.spec.js --project=chromium -g \"Relay-pinned\"",
 		"test:e2e:public-relay": "E2E_RELAY_MODE=public E2E_RELAY_PINNING_PROOF=true playwright test e2e/collaboration.spec.js --project=chromium",
 		"test:consent": "playwright test e2e/consent-screen.spec.js"

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -119,6 +119,7 @@ export async function initializeP2P(options = /** @type {{ todoDbAddress?: strin
 
 		// Mark initialization as complete
 		initializationStore.set({ isInitializing: false, isInitialized: true, error: null });
+		installPublicDiagnostics();
 		installE2ETestHooks();
 		console.log('🎉 P2P initialization completed successfully!');
 	} catch (error) {
@@ -232,13 +233,10 @@ function sanitizeDatabaseNameSegment(value) {
 	return value.replace(/[^a-zA-Z0-9._-]/g, '-');
 }
 
-function installE2ETestHooks() {
-	if (typeof window === 'undefined' || import.meta.env.VITE_E2E !== 'true') return;
-
-	/** @type {Window & typeof globalThis & { __simpleTodoE2E?: Record<string, unknown> }} */ (
-		window
-	).__simpleTodoE2E = {
+function getReadOnlyDiagnostics() {
+	return {
 		getPeerId: () => peerId,
+		getDatabaseAddress: () => get(todoDBAddressStore),
 		getMultiaddrs: () => {
 			const ownAddrs =
 				libp2p?.getMultiaddrs?.().map((/** @type {any} */ addr) => addr.toString()) ?? [];
@@ -248,6 +246,41 @@ function installE2ETestHooks() {
 					?.multiaddrs?.map((/** @type {any} */ addr) => addr.toString()) ?? [];
 			return Array.from(new Set([...ownAddrs, ...peerStoreAddrs]));
 		},
+		getConnections: () =>
+			libp2p?.getConnections?.().map((/** @type {any} */ connection) => ({
+				remotePeer: connection.remotePeer?.toString() ?? null,
+				remoteAddr: connection.remoteAddr?.toString() ?? null
+			})) ?? [],
+		getOrbitDBIdentity: () =>
+			orbitdb?.identity
+				? {
+						id: orbitdb.identity.id ?? null,
+						hash: orbitdb.identity.hash ?? null
+					}
+				: null,
+		hasOrbitDBIdentity: async (/** @type {unknown} */ hash) =>
+			typeof hash === 'string' && Boolean(await orbitdb?.identities?.getIdentity?.(hash)),
+		publishOrbitDBIdentity
+	};
+}
+
+function installPublicDiagnostics() {
+	if (typeof window === 'undefined') return;
+
+	/** @type {Window & typeof globalThis & { __simpleTodoDiagnostics?: Record<string, unknown> }} */ (
+		window
+	).__simpleTodoDiagnostics = Object.freeze(getReadOnlyDiagnostics());
+}
+
+function installE2ETestHooks() {
+	if (typeof window === 'undefined' || import.meta.env.VITE_E2E !== 'true') return;
+
+	const diagnostics = getReadOnlyDiagnostics();
+
+	/** @type {Window & typeof globalThis & { __simpleTodoE2E?: Record<string, unknown> }} */ (
+		window
+	).__simpleTodoE2E = {
+		...diagnostics,
 		getConnectionCount: () => libp2p?.getConnections?.().length ?? 0,
 		getConnectedPeerIds: () =>
 			libp2p
@@ -272,11 +305,6 @@ function installE2ETestHooks() {
 		hasOrbitDBIdentity: async (/** @type {unknown} */ hash) =>
 			typeof hash === 'string' && Boolean(await orbitdb?.identities?.getIdentity?.(hash)),
 		publishOrbitDBIdentity,
-		getConnections: () =>
-			libp2p?.getConnections?.().map((/** @type {any} */ connection) => ({
-				remotePeer: connection.remotePeer?.toString() ?? null,
-				remoteAddr: connection.remoteAddr?.toString() ?? null
-			})) ?? [],
 		getWebRTCEnabled,
 		setWebRTCEnabled,
 		connectToMultiaddr
@@ -471,7 +499,11 @@ async function collectUint8Array(value) {
 		return concatUint8Arrays(chunks);
 	}
 
-	if (iterable && typeof iterable[Symbol.iterator] === 'function' && !(value instanceof Uint8Array)) {
+	if (
+		iterable &&
+		typeof iterable[Symbol.iterator] === 'function' &&
+		!(value instanceof Uint8Array)
+	) {
 		const chunks = [];
 		for (const chunk of iterable) {
 			chunks.push(toUint8Array(chunk));


### PR DESCRIPTION
Consolidates collab01 independently without importing main tutorial semantics.\n\nDeployment:\n- @le-space/node 0.6.22 authenticated CAR publishing\n- exact CIDv1 output and domain verification\n- processed STORE gate before domain linking\n- versioned simple-todo-collab01 website aggregate\n\nRemote E2E:\n- production-safe diagnostics\n- distinct initial databases asserted\n- Agent B opens Agent A's address through the collab01 UI\n- public relay and mutual OrbitDB identity evidence\n- GitHub artifacts and TestingBot video links\n- coordinator never transfers OrbitDB entries or blocks\n\nLocal verification:\n- unit tests: 2/2 passed\n- production build: passed\n- existing collab01 Chromium suite: 4 passed, 2 opt-in skipped\n\nImportant new finding: the strict provider-neutral scenario currently reaches address exchange, mutual identities and peer connections, but local replication does not complete unless the legacy test's explicit block-transfer helper is used. The helper is intentionally not used here because it would mask the remote replication path. The public TestingBot run after deployment will determine whether this is local-relay-specific or a production issue.