### PR TITLE
Fix collab01 cross-provider peer connection

### DIFF
--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -70,6 +70,30 @@ export class TodoBrowserAgent {
 		return this.diagnostics();
 	}
 
+	async connectToPeer(address, peerId) {
+		const outcome = await this.page.evaluate(async (remoteAddress) => {
+			const connect = window.__simpleTodoDiagnostics?.connectToMultiaddr;
+			if (typeof connect !== 'function') {
+				throw new Error('Public libp2p connection hook is unavailable.');
+			}
+			return connect(remoteAddress);
+		}, address);
+
+		if (outcome?.status !== 'stable') {
+			throw new Error(`Direct browser connection did not remain stable: ${outcome?.detail}`);
+		}
+
+		await this.page.waitForFunction(
+			(remotePeer) =>
+				(window.__simpleTodoDiagnostics?.getConnections?.() ?? []).some(
+					(connection) => connection.remotePeer === remotePeer
+				),
+			peerId,
+			{ timeout: this.timeout, polling: 1_000 }
+		);
+		return outcome;
+	}
+
 	async createTodo(text) {
 		await this.todoInput().fill(text);
 		await this.page.getByRole('button', { name: 'Add TODO' }).click();
@@ -106,9 +130,7 @@ export class TodoBrowserAgent {
 	}
 
 	async getOrbitDBIdentity() {
-		return this.page.evaluate(
-			() => window.__simpleTodoDiagnostics?.getOrbitDBIdentity?.() ?? null
-		);
+		return this.page.evaluate(() => window.__simpleTodoDiagnostics?.getOrbitDBIdentity?.() ?? null);
 	}
 
 	async waitForOrbitDBIdentity(hash) {

--- a/e2e/remote/collab01-scenario.mjs
+++ b/e2e/remote/collab01-scenario.mjs
@@ -7,6 +7,13 @@ function hasPublicRelayConnection(diagnostics) {
 	);
 }
 
+function selectBrowserDialAddress(diagnostics) {
+	return diagnostics.multiaddrs.find((address) => {
+		const normalized = address.toLowerCase();
+		return normalized.includes('/p2p-circuit/') && normalized.includes('/webrtc/');
+	});
+}
+
 export async function runCollab01RemoteScenario({
 	browserA,
 	browserB,
@@ -71,6 +78,13 @@ export async function runCollab01RemoteScenario({
 			agentA.waitForOrbitDBIdentity(identityB?.hash),
 			agentB.waitForOrbitDBIdentity(identityA?.hash)
 		]);
+
+		const agentADialAddress = selectBrowserDialAddress(result.agents.a);
+		if (!agentADialAddress) {
+			throw new Error('Agent A did not advertise a browser-dialable relay/WebRTC address.');
+		}
+		result.directConnection = await agentB.connectToPeer(agentADialAddress, result.agents.a.peerId);
+		result.agents.b = await agentB.diagnostics();
 
 		const bToAStarted = Date.now();
 		await agentB.createTodo(todoFromB);

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -260,7 +260,8 @@ function getReadOnlyDiagnostics() {
 				: null,
 		hasOrbitDBIdentity: async (/** @type {unknown} */ hash) =>
 			typeof hash === 'string' && Boolean(await orbitdb?.identities?.getIdentity?.(hash)),
-		publishOrbitDBIdentity
+		publishOrbitDBIdentity,
+		connectToMultiaddr
 	};
 }
 


### PR DESCRIPTION
Summary: expose the existing manual libp2p dial operation through public diagnostics; connect the TestingBot browser directly to the GitHub browser through its advertised relay/WebRTC multiaddr; verify the remote peer ID before bidirectional OrbitDB replication. The coordinator exchanges only the address, never OrbitDB entries or blocks. Local verification: unit tests 2 passed; production build passed; Chromium collaboration suite 4 passed and 2 opt-in relay tests skipped.