### PR TITLE
Retry transient Aleph CAR upload failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,8 +117,10 @@ jobs:
           ALEPH_SITE_PIN: 'true'
           ALEPH_SITE_NAME: simple-todo-collab01
           ALEPH_SITE_CHANNEL: ALEPH-CLOUDSOLUTIONS
+          ALEPH_SITE_PUBLISH_ATTEMPTS: '3'
+          ALEPH_SITE_PUBLISH_RETRY_DELAY_MS: '15000'
           ALEPH_PRIVATE_KEY: ${{ secrets.ALEPH_PRIVATE_KEY }}
-        run: node --input-type=module -e "import('/tmp/le-space-deployer/node_modules/@le-space/node/index.js').then((m) => m.runSiteMode())"
+        run: node scripts/run-aleph-site-publish-with-retry.mjs
 
   link-domain:
     needs: build-and-deploy

--- a/scripts/run-aleph-site-publish-with-retry.mjs
+++ b/scripts/run-aleph-site-publish-with-retry.mjs
@@ -1,0 +1,41 @@
+const deployModulePath =
+	process.env.ALEPH_DEPLOY_MODULE_PATH ??
+	'/tmp/le-space-deployer/node_modules/@le-space/node/index.js';
+const maxAttempts = Number.parseInt(process.env.ALEPH_SITE_PUBLISH_ATTEMPTS ?? '3', 10);
+const initialDelayMs = Number.parseInt(
+	process.env.ALEPH_SITE_PUBLISH_RETRY_DELAY_MS ?? '15000',
+	10
+);
+
+if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+	throw new Error('ALEPH_SITE_PUBLISH_ATTEMPTS must be a positive integer.');
+}
+
+if (!Number.isInteger(initialDelayMs) || initialDelayMs < 0) {
+	throw new Error('ALEPH_SITE_PUBLISH_RETRY_DELAY_MS must be a non-negative integer.');
+}
+
+const { runSiteMode } = await import(deployModulePath);
+
+for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+	try {
+		await runSiteMode();
+		break;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const transientFailure =
+			/HTTP (?:408|425|429|5\d\d)\b/i.test(message) ||
+			/ECONNRESET|ECONNREFUSED|ETIMEDOUT|fetch failed|socket hang up/i.test(message);
+
+		if (!transientFailure || attempt === maxAttempts) {
+			throw error;
+		}
+
+		const delayMs = initialDelayMs * 2 ** (attempt - 1);
+		console.warn(
+			`Aleph site publication attempt ${attempt}/${maxAttempts} failed transiently: ${message}`
+		);
+		console.warn(`Retrying the same site build in ${delayMs}ms.`);
+		await new Promise((resolve) => setTimeout(resolve, delayMs));
+	}
+}


### PR DESCRIPTION
Retries Aleph site publication up to three times with exponential backoff for HTTP 408, 425, 429, 5xx, and transient network failures. Permanent authentication, payment, and validation errors still fail immediately. The domain-link job remains gated on a processed STORE. Verified with a mock that fails twice with HTTP 502 and succeeds on the third attempt; script syntax, formatting, and workflow YAML parsing pass.