### PR TITLE
Require observed browser WebRTC topology in remote E2E

### DIFF
--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -70,30 +70,6 @@ export class TodoBrowserAgent {
 		return this.diagnostics();
 	}
 
-	async connectToPeer(address, peerId) {
-		const outcome = await this.page.evaluate(async (remoteAddress) => {
-			const connect = window.__simpleTodoDiagnostics?.connectToMultiaddr;
-			if (typeof connect !== 'function') {
-				throw new Error('Public libp2p connection hook is unavailable.');
-			}
-			return connect(remoteAddress);
-		}, address);
-
-		if (outcome?.status !== 'stable') {
-			throw new Error(`Direct browser connection did not remain stable: ${outcome?.detail}`);
-		}
-
-		await this.page.waitForFunction(
-			(remotePeer) =>
-				(window.__simpleTodoDiagnostics?.getConnections?.() ?? []).some(
-					(connection) => connection.remotePeer === remotePeer
-				),
-			peerId,
-			{ timeout: this.timeout, polling: 1_000 }
-		);
-		return outcome;
-	}
-
 	async createTodo(text) {
 		await this.todoInput().fill(text);
 		await this.page.getByRole('button', { name: 'Add TODO' }).click();

--- a/e2e/remote/collab01-scenario.mjs
+++ b/e2e/remote/collab01-scenario.mjs
@@ -7,11 +7,39 @@ function hasPublicRelayConnection(diagnostics) {
 	);
 }
 
-function selectBrowserDialAddress(diagnostics) {
-	return diagnostics.multiaddrs.find((address) => {
-		const normalized = address.toLowerCase();
-		return normalized.includes('/p2p-circuit/') && normalized.includes('/webrtc/');
-	});
+function findWebRTCPeerConnection(diagnostics, expectedPeerId) {
+	return diagnostics.connections.find(
+		({ remotePeer, remoteAddr }) =>
+			remotePeer === expectedPeerId && remoteAddr?.toLowerCase().includes('/webrtc')
+	);
+}
+
+async function waitForWebRTCPeerConnection(agentA, agentB, peerIdA, peerIdB, timeoutMs = 120_000) {
+	const deadline = Date.now() + timeoutMs;
+
+	while (Date.now() < deadline) {
+		const [diagnosticsA, diagnosticsB] = await Promise.all([
+			agentA.diagnostics(),
+			agentB.diagnostics()
+		]);
+		const observedByA = findWebRTCPeerConnection(diagnosticsA, peerIdB);
+		const observedByB = findWebRTCPeerConnection(diagnosticsB, peerIdA);
+
+		if (observedByA || observedByB) {
+			return {
+				observedBy: observedByA ? 'agent-a' : 'agent-b',
+				connection: observedByA ?? observedByB,
+				diagnosticsA,
+				diagnosticsB
+			};
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 1_000));
+	}
+
+	throw new Error(
+		`Timed out waiting for a direct WebRTC connection between ${peerIdA} and ${peerIdB}.`
+	);
 }
 
 export async function runCollab01RemoteScenario({
@@ -79,12 +107,19 @@ export async function runCollab01RemoteScenario({
 			agentB.waitForOrbitDBIdentity(identityA?.hash)
 		]);
 
-		const agentADialAddress = selectBrowserDialAddress(result.agents.a);
-		if (!agentADialAddress) {
-			throw new Error('Agent A did not advertise a browser-dialable relay/WebRTC address.');
-		}
-		result.directConnection = await agentB.connectToPeer(agentADialAddress, result.agents.a.peerId);
-		result.agents.b = await agentB.diagnostics();
+		const webRTCObservation = await waitForWebRTCPeerConnection(
+			agentA,
+			agentB,
+			result.agents.a.peerId,
+			result.agents.b.peerId
+		);
+		result.directConnection = {
+			transport: 'webrtc',
+			observedBy: webRTCObservation.observedBy,
+			...webRTCObservation.connection
+		};
+		result.agents.a = webRTCObservation.diagnosticsA;
+		result.agents.b = webRTCObservation.diagnosticsB;
 
 		const bToAStarted = Date.now();
 		await agentB.createTodo(todoFromB);

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -260,8 +260,7 @@ function getReadOnlyDiagnostics() {
 				: null,
 		hasOrbitDBIdentity: async (/** @type {unknown} */ hash) =>
 			typeof hash === 'string' && Boolean(await orbitdb?.identities?.getIdentity?.(hash)),
-		publishOrbitDBIdentity,
-		connectToMultiaddr
+		publishOrbitDBIdentity
 	};
 }
 


### PR DESCRIPTION
Removes the explicit manual peer dial introduced in PR 12. The remote scenario now waits for each browser's public relay connection plus a browser-to-browser connection whose remote peer is the other test agent and whose address contains WebRTC. Observation on either side is accepted because libp2p transport labeling can be asymmetric. No OrbitDB entries or blocks pass through the coordinator. Local formatting, 2 unit tests, and production build pass.