### PR TITLE
Remove custom entry bridge and require native OrbitDB sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,9 +65,9 @@ jobs:
             echo '| --- | --- |'
             echo '| WebRTC disabled: peers remain connected through circuit relay | Runs |'
             echo '| Alice and Bob receive distinct OrbitDB addresses and identities | Runs |'
-            echo '| Bob opens Alice’s database and replicates a todo to Alice | Runs |'
-            echo '| Alice opens Bob’s database and replicates a todo to Bob | Runs |'
-            echo '| Late peer reads a todo previously replicated by the relay, in both directions | Opt-in with `E2E_RELAY_PINNING_PROOF=true` |'
+            echo '| Bob opens Alice’s database; both wait for the native OrbitDB peer join; Bob’s todo replicates to Alice | Runs |'
+            echo '| Both open Bob’s database; both wait for the native OrbitDB peer join; Alice’s todo replicates to Bob | Runs |'
+            echo '| Custom entry bridge, coordinator entry transfer, or snapshot fallback | Not used |'
           } >> "$GITHUB_STEP_SUMMARY"
 
   build-and-deploy:

--- a/e2e/collaboration.spec.js
+++ b/e2e/collaboration.spec.js
@@ -1,10 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { readFileSync } from 'node:fs';
 
 const testUrl = process.env.BROWSERSTACK_BUILD_NAME ? 'https://simple-todo.le-space.de' : '/';
 const collaborationTimeout = 90000;
-const relayInfoUrl = new URL('./relay-info.json', import.meta.url);
-const runRelayPinningProof = process.env.E2E_RELAY_PINNING_PROOF === 'true';
 
 test.describe.serial('WebRTC transport toggle', () => {
 	test.skip(
@@ -115,10 +112,12 @@ test.describe.serial('Todo collaboration', () => {
 		const bobIdentity = await getOrbitDBIdentity(bob);
 		await publishOrbitDBIdentity(bob);
 		await waitForKnownOrbitDBIdentity(alice, bobIdentity?.hash, 'Alice knows Bob OrbitDB identity');
+		await Promise.all([
+			waitForOrbitDBPeer(alice, bobPeerId, 'Alice OrbitDB sync -> Bob'),
+			waitForOrbitDBPeer(bob, alicePeerId, 'Bob OrbitDB sync -> Alice')
+		]);
 		await addTodo(bob, bobTodoInAliceDb);
-		await announceTodoDatabaseEntries(bob, { attempts: 3, delayMs: 3000 });
-		await transferTodoDatabaseEntries(bob, alice);
-		await expectTodoWithReplicationPoll(alice, bobTodoInAliceDb, bob);
+		await expectTodoWithReplicationPoll(alice, bobTodoInAliceDb);
 	});
 
 	test('Alice opens Bob todo database and Bob sees Alice todo', async () => {
@@ -135,45 +134,12 @@ test.describe.serial('Todo collaboration', () => {
 		const aliceIdentity = await getOrbitDBIdentity(alice);
 		await publishOrbitDBIdentity(alice);
 		await waitForKnownOrbitDBIdentity(bob, aliceIdentity?.hash, 'Bob knows Alice OrbitDB identity');
+		await Promise.all([
+			waitForOrbitDBPeer(alice, bobPeerId, 'Alice OrbitDB sync -> Bob'),
+			waitForOrbitDBPeer(bob, alicePeerId, 'Bob OrbitDB sync -> Alice')
+		]);
 		await addTodo(alice, aliceTodoInBobDb);
-		await announceTodoDatabaseEntries(alice, { attempts: 3, delayMs: 3000 });
-		await transferTodoDatabaseEntries(alice, bob);
-		await expectTodoWithReplicationPoll(bob, aliceTodoInBobDb, alice);
-	});
-});
-
-test.describe.serial('Relay-pinned todo replication', () => {
-	test.skip(
-		!!process.env.BROWSERSTACK_BUILD_NAME,
-		'Relay pinning tests require the relay-backed Playwright server.'
-	);
-	test.skip(
-		!runRelayPinningProof,
-		'Set E2E_RELAY_PINNING_PROOF=true to run relay-pinned proof tests.'
-	);
-
-	const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-	test('Bob opens Alice database after the relay replicated Alice todo', async ({ browser }) => {
-		test.setTimeout(collaborationTimeout * 4);
-
-		await expectTodoReplicatedFromRelay({
-			browser,
-			sourceName: 'Alice',
-			targetName: 'Bob',
-			todoText: `alice-${runId}-relay-pinned-before-bob-open`
-		});
-	});
-
-	test('Alice opens Bob database after the relay replicated Bob todo', async ({ browser }) => {
-		test.setTimeout(collaborationTimeout * 4);
-
-		await expectTodoReplicatedFromRelay({
-			browser,
-			sourceName: 'Bob',
-			targetName: 'Alice',
-			todoText: `bob-${runId}-relay-pinned-before-alice-open`
-		});
+		await expectTodoWithReplicationPoll(bob, aliceTodoInBobDb);
 	});
 });
 
@@ -341,6 +307,20 @@ async function waitForKnownOrbitDBIdentity(page, hash, label) {
 		.toBe(true);
 }
 
+async function waitForOrbitDBPeer(page, peerId, label) {
+	await expect
+		.poll(
+			() =>
+				page.evaluate(
+					(expectedPeerId) =>
+						window.__simpleTodoDiagnostics?.getDatabasePeers?.().includes(expectedPeerId) ?? false,
+					peerId
+				),
+			{ message: label, timeout: collaborationTimeout }
+		)
+		.toBe(true);
+}
+
 /**
  * @param {import('@playwright/test').Page} page
  * @param {string} text
@@ -384,16 +364,11 @@ async function expectTodo(page, text) {
 /**
  * @param {import('@playwright/test').Page} page
  * @param {string} text
- * @param {import('@playwright/test').Page} [sourcePage]
  */
-async function expectTodoWithReplicationPoll(page, text, sourcePage) {
+async function expectTodoWithReplicationPoll(page, text) {
 	const deadline = Date.now() + collaborationTimeout;
 
 	while (Date.now() < deadline) {
-		if (sourcePage) {
-			await announceTodoDatabaseEntries(sourcePage);
-		}
-
 		await page.evaluate(async () => {
 			if (typeof window.forceReloadTodos === 'function') {
 				await window.forceReloadTodos();
@@ -416,354 +391,6 @@ async function expectTodoWithReplicationPoll(page, text, sourcePage) {
 /**
  * @param {import('@playwright/test').Page} page
  * @param {{ attempts?: number, delayMs?: number }} [options]
- */
-async function announceTodoDatabaseEntries(page, { attempts = 1, delayMs = 0 } = {}) {
-	for (let attempt = 1; attempt <= attempts; attempt += 1) {
-		await expect
-			.poll(
-				() =>
-					page.evaluate(async () => {
-						if (typeof window.announceTodoDatabaseEntries !== 'function') return 0;
-						return window.announceTodoDatabaseEntries();
-					}),
-				{ timeout: collaborationTimeout }
-			)
-			.toBeGreaterThan(0);
-
-		if (attempt < attempts && delayMs > 0) {
-			await page.waitForTimeout(delayMs);
-		}
-	}
-}
-
-/**
- * @param {import('@playwright/test').Page} page
- * @param {{ attempts?: number, delayMs?: number }} [options]
- */
-async function announceTodoDatabaseEntriesToRelay(page, { attempts = 1, delayMs = 0 } = {}) {
-	const relayMultiaddr = getRelayMultiaddr();
-	if (!relayMultiaddr) return;
-
-	for (let attempt = 1; attempt <= attempts; attempt += 1) {
-		await expect
-			.poll(
-				() =>
-					page.evaluate(async (address) => {
-						if (typeof window.announceTodoDatabaseEntriesToMultiaddr !== 'function') {
-							return { sent: false, entryCount: 0 };
-						}
-						return window.announceTodoDatabaseEntriesToMultiaddr(address);
-					}, relayMultiaddr),
-				{ timeout: collaborationTimeout }
-			)
-			.toMatchObject({ sent: true });
-
-		if (attempt < attempts && delayMs > 0) {
-			await page.waitForTimeout(delayMs);
-		}
-	}
-}
-
-/**
- * @param {import('@playwright/test').Page} sourcePage
- * @param {import('@playwright/test').Page} targetPage
- */
-async function transferTodoDatabaseEntries(sourcePage, targetPage) {
-	const payload = await sourcePage.evaluate(async () => {
-		if (typeof window.exportTodoDatabaseEntries !== 'function') return null;
-		return window.exportTodoDatabaseEntries();
-	});
-
-	if (!payload) {
-		throw new Error('No Todo database entries were available to transfer.');
-	}
-
-	const targetAddress = await getActiveTodoDbAddress(targetPage);
-	expect(payload.dbAddress).toBe(targetAddress);
-
-	await targetPage.evaluate(async (entriesPayload) => {
-		if (typeof window.importTodoDatabaseEntries !== 'function') {
-			throw new Error('Todo database entry import hook is not available.');
-		}
-		await window.importTodoDatabaseEntries(entriesPayload);
-	}, payload);
-}
-
-/**
- * @param {{
- *   browser: import('@playwright/test').Browser,
- *   sourceName: string,
- *   targetName: string,
- *   todoText: string
- * }} options
- */
-async function expectTodoReplicatedFromRelay({ browser, sourceName, targetName, todoText }) {
-	const sourceContext = await browser.newContext();
-	const targetContext = await browser.newContext();
-	const sourcePage = await sourceContext.newPage();
-	const targetPage = await targetContext.newPage();
-	let sourceClosed = false;
-
-	try {
-		await openReadyApp(sourcePage);
-		await ensureRelayConnection(sourcePage, sourceName);
-
-		const sourceDbAddress = await getTodoDbAddress(sourcePage);
-		await publishOrbitDBIdentity(sourcePage);
-		await addTodo(sourcePage, todoText);
-		await announceTodoDatabaseEntries(sourcePage, { attempts: 3, delayMs: 3000 });
-		await announceTodoDatabaseEntriesToRelay(sourcePage, { attempts: 3, delayMs: 1000 });
-		const relayProof = await assertRelayReplicatedDatabase(
-			sourceDbAddress,
-			`${sourceName} todo database`,
-			todoText,
-			sourcePage
-		);
-		test.info().annotations.push({
-			type: 'relay-pinning-proof',
-			description: JSON.stringify({
-				sourceName,
-				targetName,
-				dbAddress: sourceDbAddress,
-				relayProof
-			})
-		});
-
-		await sourceContext.close();
-		sourceClosed = true;
-
-		await openReadyApp(targetPage);
-		await ensureRelayConnection(targetPage, targetName);
-		await loadTodoDb(targetPage, sourceDbAddress);
-		await expectTodoWithReplicationPoll(targetPage, todoText);
-	} finally {
-		await targetContext.close();
-		if (!sourceClosed) {
-			await sourceContext.close();
-		}
-	}
-}
-
-/**
- * @param {string} dbAddress
- * @param {string} label
- * @param {string} todoText
- * @param {import('@playwright/test').Page} [sourcePage]
- */
-async function assertRelayReplicatedDatabase(dbAddress, label, todoText, sourcePage) {
-	const relayHttpOrigin = getRelayHttpOrigin();
-	const deadline = Date.now() + collaborationTimeout;
-	let lastError = '';
-
-	while (Date.now() < deadline) {
-		try {
-			if (sourcePage) {
-				await announceTodoDatabaseEntries(sourcePage);
-				await announceTodoDatabaseEntriesToRelay(sourcePage);
-			}
-
-			let sync = null;
-			let syncError = '';
-
-			try {
-				sync = await syncRelayDatabase(relayHttpOrigin, dbAddress, sourcePage, 2000);
-			} catch (error) {
-				syncError = error instanceof Error ? error.message : String(error);
-			}
-
-			const databases = await relayFetchJson(
-				`${relayHttpOrigin}/pinning/databases?address=${encodeURIComponent(dbAddress)}`
-			);
-			const databaseRecord = Array.isArray(databases?.databases)
-				? databases.databases.find((entry) => entry?.address === dbAddress)
-				: null;
-			const relayEntryCount =
-				typeof sync?.entryCount === 'number'
-					? sync.entryCount
-					: typeof databaseRecord?.entryCount === 'number'
-						? databaseRecord.entryCount
-						: 0;
-
-			if (
-				databaseRecord &&
-				relayEntryCount > 0 &&
-				relayProofContainsTodo({ sync, databaseRecord }, todoText)
-			) {
-				return {
-					sync,
-					syncError,
-					databases
-				};
-			}
-
-			lastError = JSON.stringify({ sync, syncError, databases });
-		} catch (error) {
-			lastError = error instanceof Error ? error.message : String(error);
-		}
-
-		await sleep(2000);
-	}
-
-	throw new Error(`Timed out waiting for relay to replicate ${label}: ${lastError}`);
-}
-
-/**
- * @param {{ sync: any, databaseRecord: any }} proof
- * @param {string} todoText
- */
-function relayProofContainsTodo(proof, todoText) {
-	return JSON.stringify(proof).includes(todoText);
-}
-
-/**
- * @param {string} relayHttpOrigin
- * @param {string} dbAddress
- * @param {import('@playwright/test').Page | undefined} sourcePage
- * @param {number} [timeoutMs]
- */
-async function syncRelayDatabase(relayHttpOrigin, dbAddress, sourcePage, timeoutMs = 30000) {
-	let announceInterval = /** @type {ReturnType<typeof setInterval> | null} */ (null);
-
-	if (sourcePage) {
-		announceInterval = setInterval(() => {
-			void announceTodoDatabaseEntries(sourcePage).catch(() => {
-				// The source page may close while a sync attempt is being cleaned up.
-			});
-			void announceTodoDatabaseEntriesToRelay(sourcePage).catch(() => {
-				// The source page may close while a sync attempt is being cleaned up.
-			});
-		}, 1000);
-	}
-
-	try {
-		return await relayFetchJson(
-			`${relayHttpOrigin}/pinning/sync`,
-			{
-				method: 'POST',
-				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify({ dbAddress })
-			},
-			timeoutMs
-		);
-	} finally {
-		if (announceInterval) {
-			clearInterval(announceInterval);
-		}
-	}
-}
-
-function getRelayHttpOrigin() {
-	const fromEnv = process.env.E2E_RELAY_HTTP_ORIGIN?.trim();
-	if (fromEnv) return fromEnv.replace(/\/+$/, '');
-
-	const relayInfo = getRelayInfo();
-	const fromRelayInfo =
-		typeof relayInfo?.httpOrigin === 'string' ? relayInfo.httpOrigin.trim() : '';
-
-	if (!fromRelayInfo) {
-		throw new Error('Missing relay HTTP origin. Set E2E_RELAY_HTTP_ORIGIN for public relay runs.');
-	}
-
-	return fromRelayInfo.replace(/\/+$/, '');
-}
-
-/**
- * @param {import('@playwright/test').Page} page
- * @param {string} label
- */
-async function ensureRelayConnection(page, label) {
-	const relayMultiaddr = getRelayMultiaddr();
-	const deadline = Date.now() + collaborationTimeout;
-	let lastDialError = '';
-
-	while (Date.now() < deadline) {
-		const hasConnection = await page.evaluate(
-			() => (window.__simpleTodoE2E?.getConnectionCount?.() ?? 0) >= 1
-		);
-		if (hasConnection) return;
-
-		if (relayMultiaddr) {
-			try {
-				const dialResult = await page.evaluate(async (address) => {
-					const hook = window.__simpleTodoE2E?.connectToMultiaddr;
-					if (typeof hook === 'function') {
-						return await hook(address);
-					}
-					return null;
-				}, relayMultiaddr);
-				if (dialResult?.status === 'stable') return;
-			} catch (error) {
-				lastDialError = error instanceof Error ? error.message : String(error);
-			}
-
-			await page.waitForTimeout(2000);
-		} else {
-			break;
-		}
-	}
-
-	try {
-		await waitForConnectionCount(page, 1);
-	} catch (error) {
-		if (!lastDialError) throw error;
-		throw new Error(
-			`Timed out waiting for ${label} relay connection. Last explicit relay dial error: ${lastDialError}`
-		);
-	}
-}
-
-function getRelayMultiaddr() {
-	const fromEnv =
-		process.env.E2E_PUBLIC_RELAY_BOOTSTRAP_ADDR?.trim() ||
-		process.env.VITE_RELAY_BOOTSTRAP_ADDR_PROD?.trim() ||
-		process.env.VITE_RELAY_BOOTSTRAP_ADDR_DEV?.trim() ||
-		'';
-	if (fromEnv) return fromEnv.split(',')[0].trim();
-
-	const relayInfo = getRelayInfo();
-	const fromRelayInfo = typeof relayInfo?.multiaddr === 'string' ? relayInfo.multiaddr.trim() : '';
-	return fromRelayInfo.split(',')[0].trim();
-}
-
-function getRelayInfo() {
-	return JSON.parse(readFileSync(relayInfoUrl, 'utf8'));
-}
-
-/**
- * @param {string} url
- * @param {RequestInit} [options]
- * @param {number} [timeoutMs]
- */
-async function relayFetchJson(url, options = {}, timeoutMs = 30000) {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-	try {
-		const response = await fetch(url, {
-			...options,
-			signal: controller.signal
-		});
-		const body = await response.text();
-
-		if (!response.ok) {
-			throw new Error(`${options.method || 'GET'} ${url} returned ${response.status}: ${body}`);
-		}
-
-		return JSON.parse(body);
-	} finally {
-		clearTimeout(timeout);
-	}
-}
-
-/**
- * @param {number} ms
- */
-function sleep(ms) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * @param {import('@playwright/test').Browser} browser
  */
 async function createAliceAndBob(browser) {
 	const aliceContext = await browser.newContext();

--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -43,6 +43,7 @@ export class TodoBrowserAgent {
 					window.getTodoDatabaseAddress?.() ?? diagnostics?.getDatabaseAddress?.() ?? null,
 				multiaddrs: diagnostics?.getMultiaddrs?.() ?? [],
 				connections: diagnostics?.getConnections?.() ?? [],
+				databasePeers: diagnostics?.getDatabasePeers?.() ?? [],
 				appStamp: document.querySelector('header p')?.textContent?.trim() ?? null,
 				userAgent: navigator.userAgent
 			};
@@ -86,13 +87,14 @@ export class TodoBrowserAgent {
 		await expect(input).toHaveValue(address, { timeout: this.timeout });
 	}
 
-	async announceDatabaseEntries() {
-		await this.page.evaluate(async () => {
-			if (typeof window.announceTodoDatabaseEntries !== 'function') {
-				throw new Error('Todo database entry announcement hook is unavailable.');
-			}
-			await window.announceTodoDatabaseEntries({ attempts: 3, delayMs: 3_000 });
-		});
+	async waitForDatabasePeer(peerId) {
+		await this.page.waitForFunction(
+			(expectedPeerId) =>
+				(window.__simpleTodoDiagnostics?.getDatabasePeers?.() ?? []).includes(expectedPeerId),
+			peerId,
+			{ timeout: this.timeout, polling: 1_000 }
+		);
+		return this.diagnostics();
 	}
 
 	async publishOrbitDBIdentity() {

--- a/e2e/remote/collab01-scenario.mjs
+++ b/e2e/remote/collab01-scenario.mjs
@@ -120,16 +120,22 @@ export async function runCollab01RemoteScenario({
 		};
 		result.agents.a = webRTCObservation.diagnosticsA;
 		result.agents.b = webRTCObservation.diagnosticsB;
+		[result.agents.a, result.agents.b] = await Promise.all([
+			agentA.waitForDatabasePeer(result.agents.b.peerId),
+			agentB.waitForDatabasePeer(result.agents.a.peerId)
+		]);
+		result.orbitdbSync = {
+			agentARecognizedAgentB: result.agents.a.databasePeers.includes(result.agents.b.peerId),
+			agentBRecognizedAgentA: result.agents.b.databasePeers.includes(result.agents.a.peerId)
+		};
 
 		const bToAStarted = Date.now();
 		await agentB.createTodo(todoFromB);
-		await agentB.announceDatabaseEntries();
 		await agentA.waitForTodo(todoFromB);
 		result.replication.bToAMs = Date.now() - bToAStarted;
 
 		const aToBStarted = Date.now();
 		await agentA.createTodo(todoFromA);
-		await agentA.announceDatabaseEntries();
 		await agentB.waitForTodo(todoFromA);
 		result.replication.aToBMs = Date.now() - aToBStarted;
 		result.passed = true;

--- a/src/lib/db-actions.js
+++ b/src/lib/db-actions.js
@@ -1,12 +1,5 @@
 import { writable, derived, get } from 'svelte/store';
-import { pipe } from 'it-pipe';
-import { multiaddr } from '@multiformats/multiaddr';
-import {
-	exportOrbitDBAddressBlocks,
-	importOrbitDBAddressBlocks,
-	libp2pStore,
-	peerIdStore
-} from './p2p.js';
+import { peerIdStore } from './p2p.js';
 
 /**
  * @typedef {{
@@ -77,11 +70,6 @@ export const todosStore = writable(/** @type {TodoItem[]} */ ([]));
 export const todosCountStore = derived(todosStore, ($todos) => $todos.length);
 
 const observedDatabases = new WeakSet();
-const TODO_ENTRY_EXCHANGE_TOPIC = 'simple-todo.orbitdb-todo-entries';
-const TODO_ENTRY_EXCHANGE_PROTOCOL = '/simple-todo/orbitdb-entries/1.0.0';
-const pendingTodoEntryPayloads = new Map();
-let todoEntryBridgePubsub = /** @type {any} */ (null);
-let todoEntryBridgeLibp2p = /** @type {any} */ (null);
 
 /**
  * @param {TodoDatabase | null | undefined} todoDB
@@ -116,7 +104,6 @@ function setActiveTodoDatabase(todoDB) {
 export async function initializeDatabase(orbitdb, todoDB) {
 	orbitdbStore.set(orbitdb);
 	setActiveTodoDatabase(todoDB);
-	await setupTodoEntryBridge();
 
 	// Load existing todos
 	await loadTodos();
@@ -148,11 +135,6 @@ export async function loadTodoDatabase(address) {
 	}
 
 	try {
-		const pendingPayload = pendingTodoEntryPayloads.get(normalizedAddress);
-		if (pendingPayload) {
-			await importOrbitDBAddressBlocks(pendingPayload.blocks);
-		}
-
 		const loadedTodoDB = await orbitdb.open(normalizedAddress, {
 			type: 'keyvalue',
 			sync: true
@@ -160,9 +142,6 @@ export async function loadTodoDatabase(address) {
 
 		setActiveTodoDatabase(loadedTodoDB);
 		setupDatabaseListeners(loadedTodoDB);
-		if (pendingPayload) {
-			await importTodoDatabaseEntries(pendingPayload);
-		}
 		await loadTodos();
 
 		return {
@@ -223,7 +202,6 @@ function setupDatabaseListeners(todoDB) {
 	// Listen for new entries being added
 	todoDB.events.on('join', async (_peerId, heads) => {
 		console.log('📝 Database peer joined:', heads);
-		await announceTodoDatabaseEntries(todoDB);
 		await loadTodos();
 	});
 
@@ -232,342 +210,6 @@ function setupDatabaseListeners(todoDB) {
 		console.log('🔄 Entry updated:', entry);
 		await loadTodos();
 	});
-}
-
-/**
- * Republish the current log entries on the OrbitDB sync topic.
- * This helps late-joining browser peers receive the current TODO set after
- * they have opened an existing database address.
- *
- * @param {TodoDatabase | null} [database]
- * @returns {Promise<number>}
- */
-export async function announceTodoDatabaseEntries(database = get(todoDBStore)) {
-	if (!database?.sync?.add) return 0;
-
-	const entries =
-		(await database.log?.values?.().catch(() => null)) ??
-		(await database.log?.heads?.().catch(() => null)) ??
-		[];
-
-	for (const entry of entries) {
-		await database.sync.add(entry);
-	}
-
-	const published = await publishTodoDatabaseEntries(database, entries);
-
-	return published ? entries.length : 0;
-}
-
-/**
- * Send the current todo database proof bundle directly to a known relay address.
- *
- * @param {string} address
- * @param {TodoDatabase | null} [database]
- * @returns {Promise<{ sent: boolean, entryCount: number, dbAddress: string }>}
- */
-export async function announceTodoDatabaseEntriesToMultiaddr(
-	address,
-	database = get(todoDBStore)
-) {
-	if (!database?.sync?.add) {
-		return { sent: false, entryCount: 0, dbAddress: '' };
-	}
-
-	const entries =
-		(await database.log?.values?.().catch(() => null)) ??
-		(await database.log?.heads?.().catch(() => null)) ??
-		[];
-
-	for (const entry of entries) {
-		await database.sync.add(entry);
-	}
-
-	const payload = await exportTodoDatabaseEntries(database, entries);
-	if (!payload) {
-		return { sent: false, entryCount: entries.length, dbAddress: getDatabaseAddress(database) };
-	}
-
-	await sendTodoDatabaseEntriesToMultiaddr(address, new TextEncoder().encode(JSON.stringify(payload)));
-
-	return {
-		sent: true,
-		entryCount: entries.length,
-		dbAddress: payload.dbAddress
-	};
-}
-
-async function setupTodoEntryBridge() {
-	const libp2p = get(libp2pStore);
-	const pubsub = libp2p?.services?.pubsub;
-	if (!libp2p || !pubsub || pubsub === todoEntryBridgePubsub) return;
-
-	if (todoEntryBridgePubsub) {
-		todoEntryBridgePubsub.removeEventListener?.('message', handleTodoEntryBridgeMessage);
-		try {
-			await todoEntryBridgePubsub.unsubscribe?.(TODO_ENTRY_EXCHANGE_TOPIC);
-		} catch {
-			// ignore cleanup failures when switching libp2p instances
-		}
-	}
-
-	if (todoEntryBridgeLibp2p) {
-		try {
-			await todoEntryBridgeLibp2p.unhandle?.(TODO_ENTRY_EXCHANGE_PROTOCOL);
-		} catch {
-			// ignore cleanup failures when switching libp2p instances
-		}
-	}
-
-	todoEntryBridgeLibp2p = libp2p;
-	await todoEntryBridgeLibp2p.handle(TODO_ENTRY_EXCHANGE_PROTOCOL, handleTodoEntryBridgeStream);
-
-	todoEntryBridgePubsub = pubsub;
-	todoEntryBridgePubsub.addEventListener('message', handleTodoEntryBridgeMessage);
-	await todoEntryBridgePubsub.subscribe(TODO_ENTRY_EXCHANGE_TOPIC);
-}
-
-/**
- * @param {TodoDatabase} database
- * @param {any[]} entries
- */
-async function publishTodoDatabaseEntries(database, entries) {
-	const libp2p = get(libp2pStore);
-	const pubsub = libp2p?.services?.pubsub;
-	const payload = await exportTodoDatabaseEntries(database, entries);
-
-	if (!libp2p || !pubsub || !payload) {
-		return false;
-	}
-
-	const bytes = new TextEncoder().encode(JSON.stringify(payload));
-
-	await pubsub.publish(TODO_ENTRY_EXCHANGE_TOPIC, bytes);
-	await sendTodoDatabaseEntriesToConnectedPeers(libp2p, bytes);
-	return true;
-}
-
-/**
- * @param {TodoDatabase | null} [database]
- * @param {any[] | null} [entries]
- */
-export async function exportTodoDatabaseEntries(
-	database = get(todoDBStore),
-	entries = /** @type {any[] | null} */ (null)
-) {
-	if (!database) return null;
-
-	const dbAddress = getDatabaseAddress(database);
-	const logEntries =
-		entries ??
-		(await database.log?.values?.().catch(() => null)) ??
-		(await database.log?.heads?.().catch(() => null)) ??
-		[];
-	const records = await database.all().catch(() => []);
-	const blocks = dbAddress ? await exportOrbitDBAddressBlocks(dbAddress) : [];
-
-	if (!dbAddress || (logEntries.length === 0 && records.length === 0)) {
-		return null;
-	}
-
-	return {
-		dbAddress,
-		entries: logEntries,
-		blocks,
-		records: records.map((record) => ({
-			key: record.key,
-			value: record.value
-		}))
-	};
-}
-
-/**
- * @param {any} libp2p
- * @param {Uint8Array} bytes
- */
-async function sendTodoDatabaseEntriesToConnectedPeers(libp2p, bytes) {
-	const remotePeers = new Set(
-		(libp2p.getConnections?.() ?? [])
-			.map((/** @type {any} */ connection) => connection.remotePeer?.toString())
-			.filter(Boolean)
-	);
-
-	await Promise.allSettled(
-		Array.from(remotePeers).map(async (remotePeer) => {
-			const stream = await libp2p.dialProtocol(remotePeer, TODO_ENTRY_EXCHANGE_PROTOCOL, {
-				signal:
-					typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
-						? AbortSignal.timeout(10_000)
-						: undefined
-			});
-			await writeTodoEntryBridgeStream(stream, bytes);
-		})
-	);
-}
-
-/**
- * @param {string} address
- * @param {Uint8Array} bytes
- */
-async function sendTodoDatabaseEntriesToMultiaddr(address, bytes) {
-	const libp2p = get(libp2pStore);
-	if (!libp2p) {
-		throw new Error('P2P is not initialized yet.');
-	}
-
-	const normalizedAddress = address.trim();
-	if (!normalizedAddress) {
-		throw new Error('Missing relay multiaddr.');
-	}
-
-	const target = multiaddr(normalizedAddress);
-	const stream = await libp2p.dialProtocol(target, TODO_ENTRY_EXCHANGE_PROTOCOL, {
-		signal:
-			typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
-				? AbortSignal.timeout(10_000)
-				: undefined
-	});
-	await writeTodoEntryBridgeStream(stream, bytes);
-}
-
-/**
- * @param {any} stream
- * @param {Uint8Array} bytes
- */
-async function writeTodoEntryBridgeStream(stream, bytes) {
-	const sink = typeof stream === 'function' ? stream : stream.sink;
-	if (typeof sink === 'function') {
-		await pipe([bytes], sink);
-		return;
-	}
-
-	if (typeof stream?.send === 'function') {
-		if (stream.send(bytes) === false && typeof stream.onDrain === 'function') {
-			await stream.onDrain();
-		}
-		if (typeof stream.close === 'function') {
-			await stream.close();
-		}
-		return;
-	}
-
-	throw new Error('Todo entry bridge stream does not expose a writable interface.');
-}
-
-/**
- * @param {CustomEvent<{ topic?: string, data?: Uint8Array }>} event
- */
-async function handleTodoEntryBridgeMessage(event) {
-	if (event.detail?.topic !== TODO_ENTRY_EXCHANGE_TOPIC || !event.detail.data) return;
-
-	try {
-		const payload = JSON.parse(new TextDecoder().decode(event.detail.data));
-		await importTodoDatabaseEntries(payload);
-	} catch (error) {
-		console.warn(
-			'Failed to import bridged OrbitDB todo entries:',
-			error instanceof Error ? error.message : String(error)
-		);
-	}
-}
-
-/**
- * @param {{ stream: { source: AsyncIterable<Uint8Array | { subarray: () => Uint8Array }>, sink: (source: AsyncIterable<Uint8Array>) => Promise<void> } }} event
- */
-async function handleTodoEntryBridgeStream(event) {
-	try {
-		const stream = event?.stream ?? event;
-		const bytes = await readStreamBytes(stream.source ?? stream);
-		const payload = JSON.parse(new TextDecoder().decode(bytes));
-		await importTodoDatabaseEntries(payload);
-	} catch (error) {
-		console.warn(
-			'Failed to import streamed OrbitDB todo entries:',
-			error instanceof Error ? error.message : String(error)
-		);
-	}
-}
-
-/**
- * @param {AsyncIterable<Uint8Array | { subarray: () => Uint8Array }>} source
- * @returns {Promise<Uint8Array>}
- */
-async function readStreamBytes(source) {
-	/** @type {Uint8Array[]} */
-	const chunks = [];
-	let length = 0;
-
-	for await (const chunk of source) {
-		const bytes = chunk instanceof Uint8Array ? chunk : chunk.subarray();
-		chunks.push(bytes);
-		length += bytes.length;
-	}
-
-	const result = new Uint8Array(length);
-	let offset = 0;
-	for (const chunk of chunks) {
-		result.set(chunk, offset);
-		offset += chunk.length;
-	}
-
-	return result;
-}
-
-/**
- * @param {{ dbAddress?: unknown, entries?: unknown, records?: unknown, blocks?: unknown }} payload
- */
-export async function importTodoDatabaseEntries(payload) {
-	const todoDB = get(todoDBStore);
-	const dbAddress = typeof payload?.dbAddress === 'string' ? payload.dbAddress : '';
-	const entries = Array.isArray(payload.entries) ? payload.entries : [];
-	const records = Array.isArray(payload.records) ? payload.records : [];
-
-	await importOrbitDBAddressBlocks(payload?.blocks);
-
-	if (
-		dbAddress &&
-		(entries.length > 0 || records.length > 0 || Array.isArray(payload?.blocks))
-	) {
-		pendingTodoEntryPayloads.set(dbAddress, payload);
-	}
-
-	if (
-		!todoDB ||
-		!dbAddress ||
-		dbAddress !== getDatabaseAddress(todoDB) ||
-		(entries.length === 0 && records.length === 0)
-	) {
-		return false;
-	}
-
-	let updated = false;
-	if (todoDB.log?.joinEntry) {
-		for (const entry of entries) {
-			if (!entry?.hash) continue;
-			try {
-				const result = await todoDB.log.joinEntry(entry);
-				updated = Boolean(result) || updated;
-			} catch {
-				// If another browser's identity block is not fetchable yet, fall back to record import below.
-			}
-		}
-	}
-
-	for (const record of records) {
-		if (!record?.key || !record?.value) continue;
-		const existing = await todoDB.get(record.key);
-		if (existing) continue;
-
-		await todoDB.put(record.key, record.value);
-		updated = true;
-	}
-
-	if (updated || entries.length > 0 || records.length > 0) {
-		await loadTodos();
-	}
-
-	pendingTodoEntryPayloads.delete(dbAddress);
-	return updated;
 }
 
 // Add a new todo
@@ -602,7 +244,6 @@ export async function addTodo(text, assignee = null) {
 		};
 
 		await todoDB.put(todoId, todo);
-		await announceTodoDatabaseEntries(todoDB);
 		console.log('✅ Todo added:', todoId);
 		return true;
 	} catch (error) {
@@ -812,24 +453,18 @@ if (typeof window !== 'undefined') {
 	 *   deleteCurrentDatabase?: typeof deleteCurrentDatabase,
 	 *   forceReloadTodos?: typeof loadTodos,
 	 *   loadTodoDatabase?: typeof loadTodoDatabase,
-	 *   announceTodoDatabaseEntries?: typeof announceTodoDatabaseEntries,
-	 *   announceTodoDatabaseEntriesToMultiaddr?: typeof announceTodoDatabaseEntriesToMultiaddr,
-	 *   exportTodoDatabaseEntries?: typeof exportTodoDatabaseEntries,
-	 *   importTodoDatabaseEntries?: typeof importTodoDatabaseEntries,
 	 *   getTodoDatabaseAddress?: () => string,
 	 *   getTodoDatabasePeerCount?: () => number,
+	 *   getTodoDatabasePeerIds?: () => string[],
 	 *   getTodoCount?: () => number
 	 * }} */ (window);
 
 	browserWindow.deleteCurrentDatabase = deleteCurrentDatabase;
 	browserWindow.forceReloadTodos = loadTodos;
 	browserWindow.loadTodoDatabase = loadTodoDatabase;
-	browserWindow.announceTodoDatabaseEntries = announceTodoDatabaseEntries;
-	browserWindow.announceTodoDatabaseEntriesToMultiaddr = announceTodoDatabaseEntriesToMultiaddr;
-	browserWindow.exportTodoDatabaseEntries = exportTodoDatabaseEntries;
-	browserWindow.importTodoDatabaseEntries = importTodoDatabaseEntries;
 	browserWindow.getTodoDatabaseAddress = () => getDatabaseAddress(get(todoDBStore));
 	browserWindow.getTodoDatabasePeerCount = () => get(todoDBStore)?.peers?.size ?? 0;
+	browserWindow.getTodoDatabasePeerIds = () => Array.from(get(todoDBStore)?.peers ?? []);
 	browserWindow.getTodoCount = () => get(todosCountStore);
 	console.log('🔧 deleteCurrentDatabase function is now available in browser console');
 }

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -237,6 +237,10 @@ function getReadOnlyDiagnostics() {
 	return {
 		getPeerId: () => peerId,
 		getDatabaseAddress: () => get(todoDBAddressStore),
+		getDatabasePeers: () =>
+			typeof window !== 'undefined' && typeof window.getTodoDatabasePeerIds === 'function'
+				? window.getTodoDatabasePeerIds()
+				: Array.from(todoDB?.peers ?? []),
 		getMultiaddrs: () => {
 			const ownAddrs =
 				libp2p?.getMultiaddrs?.().map((/** @type {any} */ addr) => addr.toString()) ?? [];
@@ -248,8 +252,12 @@ function getReadOnlyDiagnostics() {
 		},
 		getConnections: () =>
 			libp2p?.getConnections?.().map((/** @type {any} */ connection) => ({
+				id: connection.id ?? null,
 				remotePeer: connection.remotePeer?.toString() ?? null,
-				remoteAddr: connection.remoteAddr?.toString() ?? null
+				remoteAddr: connection.remoteAddr?.toString() ?? null,
+				direct: connection.direct ?? null,
+				direction: connection.direction ?? null,
+				limited: connection.limits != null
 			})) ?? [],
 		getOrbitDBIdentity: () =>
 			orbitdb?.identity


### PR DESCRIPTION
Removes the simple-todo entry pubsub topic, custom stream protocol, snapshot export/import, manual sync.add retries, coordinator entry transfer, and fallback record puts. Collaboration now waits until both OrbitDB 4 instances report the other browser in database.peers, then verifies bidirectional native replication. Connection diagnostics now include id, direct, direction, and limited state. Local verification: formatting passed, 2 unit tests passed, production build passed, and the native two-browser Chromium suite passed 4/4 with replication in both directions.