### PR TITLE
Diagnose collab01 OrbitDB sync after reload

### DIFF
--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -44,6 +44,8 @@ export class TodoBrowserAgent {
 				multiaddrs: diagnostics?.getMultiaddrs?.() ?? [],
 				connections: diagnostics?.getConnections?.() ?? [],
 				databasePeers: diagnostics?.getDatabasePeers?.() ?? [],
+				pubsubTopics: diagnostics?.getPubsubTopics?.() ?? [],
+				protocols: diagnostics?.getProtocols?.() ?? [],
 				appStamp: document.querySelector('header p')?.textContent?.trim() ?? null,
 				userAgent: navigator.userAgent
 			};
@@ -87,12 +89,34 @@ export class TodoBrowserAgent {
 		await expect(input).toHaveValue(address, { timeout: this.timeout });
 	}
 
-	async waitForDatabasePeer(peerId) {
+	async reloadAndEnsureDatabase(address) {
+		await this.page.reload({ waitUntil: 'domcontentloaded', timeout: this.timeout });
+		await expect(this.todoInput()).toBeEnabled({ timeout: this.timeout });
+		await this.page.waitForFunction(
+			() => typeof window.__simpleTodoDiagnostics?.getPeerId?.() === 'string',
+			undefined,
+			{ timeout: this.timeout }
+		);
+
+		const input = this.page.getByTestId('load-todo-db-input');
+		const addressAfterReload = await input.inputValue();
+		if (addressAfterReload !== address) {
+			await this.openDatabase(address);
+		}
+
+		return {
+			addressAfterReload,
+			reopenedDatabase: addressAfterReload !== address,
+			diagnostics: await this.diagnostics()
+		};
+	}
+
+	async waitForDatabasePeer(peerId, timeout = this.timeout) {
 		await this.page.waitForFunction(
 			(expectedPeerId) =>
 				(window.__simpleTodoDiagnostics?.getDatabasePeers?.() ?? []).includes(expectedPeerId),
 			peerId,
-			{ timeout: this.timeout, polling: 1_000 }
+			{ timeout, polling: 1_000 }
 		);
 		return this.diagnostics();
 	}

--- a/e2e/remote/collab01-scenario.mjs
+++ b/e2e/remote/collab01-scenario.mjs
@@ -110,13 +110,45 @@ export async function runCollab01RemoteScenario({
 		};
 		result.agents.a = webRTCObservation.diagnosticsA;
 		result.agents.b = webRTCObservation.diagnosticsB;
-		[result.agents.a, result.agents.b] = await Promise.all([
-			agentA.waitForDatabasePeer(result.agents.b.peerId),
-			agentB.waitForDatabasePeer(result.agents.a.peerId)
+
+		result.orbitdbBeforeReload = {
+			agentA: result.agents.a,
+			agentB: result.agents.b
+		};
+		result.reload = await agentB.reloadAndEnsureDatabase(result.agents.a.databaseAddress);
+		result.agents.b = result.reload.diagnostics;
+		if (result.agents.b.databaseAddress !== result.agents.a.databaseAddress) {
+			throw new Error("Agent B did not reopen Agent A's database after reload.");
+		}
+		if (process.env.REQUIRE_PUBLIC_RELAY === 'true') {
+			result.agents.b = await agentB.waitForPublicRelayConnection();
+		}
+		const webRTCAfterReload = await waitForWebRTCPeerConnection(
+			agentA,
+			agentB,
+			result.agents.a.peerId,
+			result.agents.b.peerId,
+			60_000
+		);
+		result.directConnectionAfterReload = {
+			transport: 'webrtc',
+			observedBy: webRTCAfterReload.observedBy,
+			...webRTCAfterReload.connection
+		};
+
+		const peerObservations = await Promise.allSettled([
+			agentA.waitForDatabasePeer(result.agents.b.peerId, 15_000),
+			agentB.waitForDatabasePeer(result.agents.a.peerId, 15_000)
 		]);
-		result.orbitdbSync = {
-			agentARecognizedAgentB: result.agents.a.databasePeers.includes(result.agents.b.peerId),
-			agentBRecognizedAgentA: result.agents.b.databasePeers.includes(result.agents.a.peerId)
+		[result.agents.a, result.agents.b] = await Promise.all([
+			agentA.diagnostics(),
+			agentB.diagnostics()
+		]);
+		result.orbitdbAfterReload = {
+			agentARecognizedAgentB: peerObservations[0].status === 'fulfilled',
+			agentBRecognizedAgentA: peerObservations[1].status === 'fulfilled',
+			agentA: result.agents.a,
+			agentB: result.agents.b
 		};
 
 		const bToAStarted = Date.now();

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -233,6 +233,8 @@ function getReadOnlyDiagnostics() {
 			typeof window !== 'undefined' && typeof window.getTodoDatabasePeerIds === 'function'
 				? window.getTodoDatabasePeerIds()
 				: Array.from(todoDB?.peers ?? []),
+		getPubsubTopics: () => libp2p?.services?.pubsub?.getTopics?.() ?? [],
+		getProtocols: () => libp2p?.getProtocols?.() ?? [],
 		getMultiaddrs: () => {
 			const ownAddrs =
 				libp2p?.getMultiaddrs?.().map((/** @type {any} */ addr) => addr.toString()) ?? [];


### PR DESCRIPTION
## Summary
- record libp2p pubsub topics and registered protocols in remote evidence
- reload browser B after it opens browser A's OrbitDB address
- record whether the selected address survived reload and reopen it when necessary
- require a fresh relay/WebRTC connection after reload
- keep database-peer observations while allowing the real bidirectional replication assertion to run

## Local findings
- unit tests: 2 passed
- against the current deployment, B reverted to its default DB after reload
- the test reopened A's address and rebuilt WebRTC successfully
- B-to-A native OrbitDB replication still timed out
- the new deployment will expose the missing topic/protocol evidence