### PR TITLE
Activate OrbitDB sync when switching collab databases

### DIFF
--- a/e2e/remote/collab01-scenario.mjs
+++ b/e2e/remote/collab01-scenario.mjs
@@ -14,6 +14,13 @@ function findWebRTCPeerConnection(diagnostics, expectedPeerId) {
 	);
 }
 
+function hasActiveOrbitDBSync(diagnostics, databaseAddress) {
+	return (
+		diagnostics.pubsubTopics.includes(databaseAddress) &&
+		diagnostics.protocols.includes(`/orbitdb/heads/orbitdb/${databaseAddress.slice('/orbitdb/'.length)}`)
+	);
+}
+
 async function waitForWebRTCPeerConnection(agentA, agentB, peerIdA, peerIdB, timeoutMs = 120_000) {
 	const deadline = Date.now() + timeoutMs;
 
@@ -150,6 +157,12 @@ export async function runCollab01RemoteScenario({
 			agentA: result.agents.a,
 			agentB: result.agents.b
 		};
+		if (!hasActiveOrbitDBSync(result.agents.a, result.agents.a.databaseAddress)) {
+			throw new Error("Agent A's active OrbitDB topic or heads protocol does not match its database.");
+		}
+		if (!hasActiveOrbitDBSync(result.agents.b, result.agents.a.databaseAddress)) {
+			throw new Error("Agent B's active OrbitDB topic or heads protocol does not match Agent A's database.");
+		}
 
 		const bToAStarted = Date.now();
 		await agentB.createTodo(todoFromB);

--- a/src/lib/db-actions.js
+++ b/src/lib/db-actions.js
@@ -34,6 +34,7 @@ import { peerIdStore } from './p2p.js';
  *   get: (key: string) => Promise<TodoRecord | TodoValue | null | undefined>
  *   put: (key: string, value: TodoValue) => Promise<unknown>
  *   del: (key: string) => Promise<unknown>
+ *   close?: () => Promise<unknown>
  *   drop: () => Promise<unknown>
  *   log?: {
  *     values?: () => Promise<any[]>
@@ -43,6 +44,7 @@ import { peerIdStore } from './p2p.js';
  *   peers?: Set<string>
  *   sync?: {
  *     add?: (entry: any) => Promise<unknown>
+ *     start?: () => Promise<unknown>
  *   }
  *   events: {
  *     on: (event: string, handler: (...args: any[]) => void | Promise<void>) => void
@@ -120,6 +122,7 @@ export async function initializeDatabase(orbitdb, todoDB) {
  */
 export async function loadTodoDatabase(address) {
 	const orbitdb = get(orbitdbStore);
+	const previousTodoDB = get(todoDBStore);
 	const normalizedAddress = address.trim();
 
 	if (!orbitdb) {
@@ -140,9 +143,17 @@ export async function loadTodoDatabase(address) {
 			sync: true
 		});
 
+		// OrbitDB returns cached database instances when an address was opened before.
+		// Starting sync explicitly is idempotent and guarantees that a reopened database
+		// subscribes to its own topic and registers its heads protocol.
+		await loadedTodoDB.sync?.start?.();
 		setActiveTodoDatabase(loadedTodoDB);
 		setupDatabaseListeners(loadedTodoDB);
 		await loadTodos();
+
+		if (previousTodoDB && previousTodoDB !== loadedTodoDB) {
+			await previousTodoDB.close?.();
+		}
 
 		return {
 			address: getDatabaseAddress(loadedTodoDB) || normalizedAddress,


### PR DESCRIPTION
## Fix
- explicitly start native OrbitDB sync for the selected database
- atomically make it active and bind listeners
- close the previously active database so its topic and heads handler are removed
- fail remote E2E early unless visible address, pubsub topic, and heads protocol match

## Validation
- unit tests: 2 passed
- local Chromium collaboration: 4 passed
- relay-only connectivity and both database-switch replication directions passed