### PR TITLE
Fix active OrbitDB lifecycle when switching databases

### DIFF
--- a/src/lib/db-actions.js
+++ b/src/lib/db-actions.js
@@ -72,6 +72,18 @@ export const todosStore = writable(/** @type {TodoItem[]} */ ([]));
 export const todosCountStore = derived(todosStore, ($todos) => $todos.length);
 
 const observedDatabases = new WeakSet();
+/** @type {((address: string) => Promise<TodoDatabase>) | null} */
+let openActiveTodoDatabase = null;
+
+/**
+ * Register the database opener owned by the P2P lifecycle. This keeps the
+ * module-level active database and the UI stores on the same OrbitDB instance.
+ *
+ * @param {((address: string) => Promise<TodoDatabase>) | null} opener
+ */
+export function setActiveTodoDatabaseOpener(opener) {
+	openActiveTodoDatabase = opener;
+}
 
 /**
  * @param {TodoDatabase | null | undefined} todoDB
@@ -138,10 +150,12 @@ export async function loadTodoDatabase(address) {
 	}
 
 	try {
-		const loadedTodoDB = await orbitdb.open(normalizedAddress, {
-			type: 'keyvalue',
-			sync: true
-		});
+		const loadedTodoDB = openActiveTodoDatabase
+			? await openActiveTodoDatabase(normalizedAddress)
+			: await orbitdb.open(normalizedAddress, {
+					type: 'keyvalue',
+					sync: true
+				});
 
 		// OrbitDB returns cached database instances when an address was opened before.
 		// Starting sync explicitly is idempotent and guarantees that a reopened database

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -12,7 +12,13 @@ import * as json from 'multiformats/codecs/json';
 import { sha512 } from 'multiformats/hashes/sha2';
 import { multiaddr } from '@multiformats/multiaddr';
 import { createLibp2pConfig } from './libp2p-config.js';
-import { initializeDatabase, todoDBAddressStore, todosStore } from './db-actions.js';
+import {
+	initializeDatabase,
+	setActiveTodoDatabaseOpener,
+	todoDBAddressStore,
+	todoDBStore,
+	todosStore
+} from './db-actions.js';
 import { getWebRTCEnabled, setWebRTCEnabled, webrtcEnabledStore } from './webrtc-settings.js';
 import { normalizeDiscoveredMultiaddrs } from './multiaddr-utils.js';
 
@@ -99,6 +105,7 @@ export async function initializeP2P(options = /** @type {{ todoDbAddress?: strin
 		// Create OrbitDB instance
 		console.log('🛬 Creating OrbitDB instance...');
 		orbitdb = await createOrbitDB({ ipfs: helia, id: getOrCreateOrbitDBIdentityId() });
+		setActiveTodoDatabaseOpener(openActiveTodoDatabase);
 		todoDB = await openInitialTodoDatabase(options.todoDbAddress);
 
 		console.log('✅ Database opened successfully with OrbitDBAccessController:', {
@@ -144,6 +151,7 @@ async function stopP2P() {
 	libp2pStore.set(null);
 	peerIdStore.set(null);
 	peerId = null;
+	setActiveTodoDatabaseOpener(null);
 	stopDiscoveryDialRetryInterval();
 	discoveredPeers.clear();
 
@@ -156,6 +164,25 @@ async function stopP2P() {
 	await Promise.allSettled(resources.map((resource) => resource?.stop?.() ?? resource?.close?.()));
 
 	todosStore.set([]);
+}
+
+/**
+ * Open a database through the P2P lifecycle so its active instance cannot
+ * diverge from the database exposed through the application stores.
+ *
+ * @param {string} address
+ */
+async function openActiveTodoDatabase(address) {
+	if (!orbitdb) {
+		throw new Error('OrbitDB is not initialized yet.');
+	}
+
+	const loadedTodoDB = await orbitdb.open(address, {
+		type: 'keyvalue',
+		sync: true
+	});
+	todoDB = loadedTodoDB;
+	return loadedTodoDB;
 }
 
 /**
@@ -229,10 +256,7 @@ function getReadOnlyDiagnostics() {
 	return {
 		getPeerId: () => peerId,
 		getDatabaseAddress: () => get(todoDBAddressStore),
-		getDatabasePeers: () =>
-			typeof window !== 'undefined' && typeof window.getTodoDatabasePeerIds === 'function'
-				? window.getTodoDatabasePeerIds()
-				: Array.from(todoDB?.peers ?? []),
+		getDatabasePeers: () => Array.from(get(todoDBStore)?.peers ?? []),
 		getPubsubTopics: () => libp2p?.services?.pubsub?.getTopics?.() ?? [],
 		getProtocols: () => libp2p?.getProtocols?.() ?? [],
 		getMultiaddrs: () => {


### PR DESCRIPTION
## Summary
- route database switches through the P2P lifecycle owner
- keep the active module instance and Svelte stores aligned
- read database-peer diagnostics from the active database store

## Local verification
- `pnpm run check`: passed
- `pnpm run test:unit`: 2 passed
- collaboration Chromium E2E: 4 passed, including both database-open replication directions

This addresses the remote evidence where B displayed A's address while remaining subscribed to B's former OrbitDB topic.