### PR TITLE
Restore the active OrbitDB database after reload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,3 +161,21 @@ jobs:
           ALEPH_SITE_DOMAIN_CATCH_ALL_PATH: /index.html
           ALEPH_PRIVATE_KEY: ${{ secrets.ALEPH_PRIVATE_KEY }}
         run: node --input-type=module -e "import('/tmp/le-space-deployer/node_modules/@le-space/node/index.js').then((m) => m.runSiteMode())"
+
+  start-remote-replication:
+    needs: link-domain
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Start remote replication after domain link
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh workflow run remote-replication.yml
+          --repo "${{ github.repository }}"
+          --ref collab01
+          -f app_url=https://collab01.le-space.de
+          -f provider=testingbot

--- a/e2e/collaboration.spec.js
+++ b/e2e/collaboration.spec.js
@@ -109,8 +109,17 @@ test.describe.serial('Todo collaboration', () => {
 		await waitForConnectedPeer(alice, bobPeerId, 'Alice -> Bob');
 		await waitForConnectionCount(bob, 2);
 		await loadTodoDb(bob, aliceDefaultTodoDbAddress);
+		await bob.reload();
+		await expect(bob.getByTestId('todo-input')).toBeEnabled({ timeout: collaborationTimeout });
+		await expect
+			.poll(() => getPeerId(bob), { timeout: collaborationTimeout })
+			.not.toBe('');
+		await loadTodoDb(bob, aliceDefaultTodoDbAddress);
+		const reloadedBobPeerId = await getPeerId(bob);
+		await waitForConnectedPeer(alice, reloadedBobPeerId, 'Alice -> reloaded Bob');
+		await waitForConnectedPeer(bob, alicePeerId, 'Reloaded Bob -> Alice');
 		await Promise.all([
-			waitForOrbitDBPeer(alice, bobPeerId, 'Alice OrbitDB sync -> Bob'),
+			waitForOrbitDBPeer(alice, reloadedBobPeerId, 'Alice OrbitDB sync -> reloaded Bob'),
 			waitForOrbitDBPeer(bob, alicePeerId, 'Bob OrbitDB sync -> Alice')
 		]);
 		await addTodo(bob, bobTodoInAliceDb);
@@ -302,6 +311,22 @@ async function loadTodoDb(page, address) {
 	await expect
 		.poll(() => getActiveTodoDbAddress(page), { timeout: collaborationTimeout })
 		.toBe(address);
+	await expect
+		.poll(
+			() =>
+				page.evaluate(
+					(expectedAddress) => {
+						const diagnostics = window.__simpleTodoDiagnostics;
+						const headsProtocol = `/orbitdb/heads/orbitdb/${expectedAddress.slice('/orbitdb/'.length)}`;
+						return (
+							diagnostics?.getPubsubTopics?.().includes(expectedAddress) &&
+							diagnostics?.getProtocols?.().includes(headsProtocol)
+						);
+					},
+					address
+				)
+		)
+		.toBe(true);
 	await expect(page.getByTestId('load-todo-db-input')).toHaveValue(address, {
 		timeout: collaborationTimeout
 	});

--- a/src/lib/active-todo-database.js
+++ b/src/lib/active-todo-database.js
@@ -1,0 +1,23 @@
+export const ACTIVE_TODO_DATABASE_STORAGE_KEY = 'simpleTodo.activeTodoDatabaseAddress';
+
+export function getStoredActiveTodoDatabaseAddress() {
+	if (typeof localStorage === 'undefined') return '';
+
+	try {
+		const address = localStorage.getItem(ACTIVE_TODO_DATABASE_STORAGE_KEY)?.trim() ?? '';
+		return address.startsWith('/orbitdb/') ? address : '';
+	} catch {
+		return '';
+	}
+}
+
+/** @param {string} address */
+export function storeActiveTodoDatabaseAddress(address) {
+	if (typeof localStorage === 'undefined' || !address.startsWith('/orbitdb/')) return;
+
+	try {
+		localStorage.setItem(ACTIVE_TODO_DATABASE_STORAGE_KEY, address);
+	} catch {
+		// Ignore browsers or modes where localStorage is unavailable.
+	}
+}

--- a/src/lib/db-actions.js
+++ b/src/lib/db-actions.js
@@ -1,5 +1,6 @@
 import { writable, derived, get } from 'svelte/store';
 import { peerIdStore } from './p2p.js';
+import { storeActiveTodoDatabaseAddress } from './active-todo-database.js';
 
 /**
  * @typedef {{
@@ -164,6 +165,7 @@ export async function loadTodoDatabase(address) {
 		setActiveTodoDatabase(loadedTodoDB);
 		setupDatabaseListeners(loadedTodoDB);
 		await loadTodos();
+		storeActiveTodoDatabaseAddress(getDatabaseAddress(loadedTodoDB) || normalizedAddress);
 
 		if (previousTodoDB && previousTodoDB !== loadedTodoDB) {
 			await previousTodoDB.close?.();

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -21,6 +21,7 @@ import {
 } from './db-actions.js';
 import { getWebRTCEnabled, setWebRTCEnabled, webrtcEnabledStore } from './webrtc-settings.js';
 import { normalizeDiscoveredMultiaddrs } from './multiaddr-utils.js';
+import { getStoredActiveTodoDatabaseAddress } from './active-todo-database.js';
 
 export { setWebRTCEnabled, webrtcEnabledStore };
 
@@ -106,7 +107,9 @@ export async function initializeP2P(options = /** @type {{ todoDbAddress?: strin
 		console.log('🛬 Creating OrbitDB instance...');
 		orbitdb = await createOrbitDB({ ipfs: helia, id: getOrCreateOrbitDBIdentityId() });
 		setActiveTodoDatabaseOpener(openActiveTodoDatabase);
-		todoDB = await openInitialTodoDatabase(options.todoDbAddress);
+		todoDB = await openInitialTodoDatabase(
+			options.todoDbAddress ?? getStoredActiveTodoDatabaseAddress()
+		);
 
 		console.log('✅ Database opened successfully with OrbitDBAccessController:', {
 			address: todoDB.address,


### PR DESCRIPTION
## Summary
- persist the manually selected OrbitDB address
- open that address directly during the next P2P initialization
- assert PubSub topic and heads protocol locally, including after reload
- dispatch the TestingBot remote workflow only after the custom-domain link succeeds

## Verification
- `pnpm run check`: 0 errors
- `pnpm run test:unit`: 2 passed
- Chromium collaboration E2E: 4 passed, including reload and both replication directions