### PR TITLE
Recreate OrbitDB when switching remote addresses

### DIFF
--- a/e2e/remote/providers.mjs
+++ b/e2e/remote/providers.mjs
@@ -15,11 +15,15 @@ export async function createTestingBotBrowser({ key, secret, buildName, testName
 		browserName: process.env.REMOTE_BROWSER || 'chrome',
 		browserVersion: process.env.REMOTE_BROWSER_VERSION || 'latest',
 		platform: process.env.REMOTE_PLATFORM || 'LINUX',
+		maxduration: Number(process.env.TESTINGBOT_MAX_DURATION_SECONDS || 900),
 		'tb:options': {
 			key,
 			secret,
 			build: buildName,
-			name: testName
+			name: testName,
+			// OrbitDB startup and cross-network convergence can legitimately keep a
+			// single Playwright command active longer than TestingBot's 90s default.
+			timeout: Number(process.env.TESTINGBOT_IDLE_TIMEOUT_SECONDS || 300)
 		}
 	};
 

--- a/src/lib/db-actions.js
+++ b/src/lib/db-actions.js
@@ -73,14 +73,14 @@ export const todosStore = writable(/** @type {TodoItem[]} */ ([]));
 export const todosCountStore = derived(todosStore, ($todos) => $todos.length);
 
 const observedDatabases = new WeakSet();
-/** @type {((address: string) => Promise<TodoDatabase>) | null} */
+/** @type {((address: string) => Promise<{ orbitdb: any, todoDB: TodoDatabase }>) | null} */
 let openActiveTodoDatabase = null;
 
 /**
  * Register the database opener owned by the P2P lifecycle. This keeps the
  * module-level active database and the UI stores on the same OrbitDB instance.
  *
- * @param {((address: string) => Promise<TodoDatabase>) | null} opener
+ * @param {((address: string) => Promise<{ orbitdb: any, todoDB: TodoDatabase }>) | null} opener
  */
 export function setActiveTodoDatabaseOpener(opener) {
 	openActiveTodoDatabase = opener;
@@ -151,12 +151,17 @@ export async function loadTodoDatabase(address) {
 	}
 
 	try {
-		const loadedTodoDB = openActiveTodoDatabase
-			? await openActiveTodoDatabase(normalizedAddress)
-			: await orbitdb.open(normalizedAddress, {
+		let loadedTodoDB;
+		if (openActiveTodoDatabase) {
+			const activeDatabase = await openActiveTodoDatabase(normalizedAddress);
+			orbitdbStore.set(activeDatabase.orbitdb);
+			loadedTodoDB = activeDatabase.todoDB;
+		} else {
+			loadedTodoDB = await orbitdb.open(normalizedAddress, {
 					type: 'keyvalue',
 					sync: true
 				});
+		}
 
 		// OrbitDB returns cached database instances when an address was opened before.
 		// Starting sync explicitly is idempotent and guarantees that a reopened database
@@ -167,7 +172,7 @@ export async function loadTodoDatabase(address) {
 		await loadTodos();
 		storeActiveTodoDatabaseAddress(getDatabaseAddress(loadedTodoDB) || normalizedAddress);
 
-		if (previousTodoDB && previousTodoDB !== loadedTodoDB) {
+		if (!openActiveTodoDatabase && previousTodoDB && previousTodoDB !== loadedTodoDB) {
 			await previousTodoDB.close?.();
 		}
 

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -170,22 +170,33 @@ async function stopP2P() {
 }
 
 /**
- * Open a database through the P2P lifecycle so its active instance cannot
- * diverge from the database exposed through the application stores.
+ * Replace OrbitDB when selecting another address. A fresh OrbitDB instance
+ * avoids retaining cached databases and sync handlers from the previous
+ * address while keeping the same Helia/libp2p node and browser identity.
  *
  * @param {string} address
  */
 async function openActiveTodoDatabase(address) {
-	if (!orbitdb) {
+	if (!orbitdb || !helia) {
 		throw new Error('OrbitDB is not initialized yet.');
 	}
 
-	const loadedTodoDB = await orbitdb.open(address, {
+	const previousOrbitDB = orbitdb;
+	orbitdb = null;
+	todoDB = null;
+	await previousOrbitDB.stop();
+
+	const nextOrbitDB = await createOrbitDB({
+		ipfs: helia,
+		id: getOrCreateOrbitDBIdentityId()
+	});
+	const loadedTodoDB = await nextOrbitDB.open(address, {
 		type: 'keyvalue',
 		sync: true
 	});
+	orbitdb = nextOrbitDB;
 	todoDB = loadedTodoDB;
-	return loadedTodoDB;
+	return { orbitdb: nextOrbitDB, todoDB: loadedTodoDB };
 }
 
 /**


### PR DESCRIPTION
## Summary
- stop the current OrbitDB instance before switching addresses
- create a fresh OrbitDB instance on the existing Helia/libp2p node
- open the selected address as its only active database
- update the shared OrbitDB store to the replacement instance
- raise TestingBot's documented 90-second command timeout to 300 seconds

## Local verification
- Svelte check: 0 errors
- Unit: 2 passed
- Chromium collaboration: 4 passed, including active topic/heads, reload, and both replication directions