### PR TITLE
fix: reuse OrbitDB when switching todo databases

### DIFF
--- a/e2e/collaboration.spec.js
+++ b/e2e/collaboration.spec.js
@@ -109,17 +109,8 @@ test.describe.serial('Todo collaboration', () => {
 		await waitForConnectedPeer(alice, bobPeerId, 'Alice -> Bob');
 		await waitForConnectionCount(bob, 2);
 		await loadTodoDb(bob, aliceDefaultTodoDbAddress);
-		await bob.reload();
-		await expect(bob.getByTestId('todo-input')).toBeEnabled({ timeout: collaborationTimeout });
-		await expect
-			.poll(() => getPeerId(bob), { timeout: collaborationTimeout })
-			.not.toBe('');
-		await loadTodoDb(bob, aliceDefaultTodoDbAddress);
-		const reloadedBobPeerId = await getPeerId(bob);
-		await waitForConnectedPeer(alice, reloadedBobPeerId, 'Alice -> reloaded Bob');
-		await waitForConnectedPeer(bob, alicePeerId, 'Reloaded Bob -> Alice');
 		await Promise.all([
-			waitForOrbitDBPeer(alice, reloadedBobPeerId, 'Alice OrbitDB sync -> reloaded Bob'),
+			waitForOrbitDBPeer(alice, bobPeerId, 'Alice OrbitDB sync -> Bob'),
 			waitForOrbitDBPeer(bob, alicePeerId, 'Bob OrbitDB sync -> Alice')
 		]);
 		await addTodo(bob, bobTodoInAliceDb);

--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -106,29 +106,6 @@ export class TodoBrowserAgent {
 		return this.diagnostics();
 	}
 
-	async reloadAndEnsureDatabase(address) {
-		await this.page.reload({ waitUntil: 'domcontentloaded', timeout: this.timeout });
-		await expect(this.todoInput()).toBeEnabled({ timeout: this.timeout });
-		await this.page.waitForFunction(
-			() => typeof window.__simpleTodoDiagnostics?.getPeerId?.() === 'string',
-			undefined,
-			{ timeout: this.timeout }
-		);
-
-		const input = this.page.getByTestId('load-todo-db-input');
-		const addressAfterReload = await input.inputValue();
-		if (addressAfterReload !== address) {
-			await this.openDatabase(address);
-		}
-		await this.waitForActiveDatabase(address);
-
-		return {
-			addressAfterReload,
-			reopenedDatabase: addressAfterReload !== address,
-			diagnostics: await this.diagnostics()
-		};
-	}
-
 	async waitForDatabasePeer(peerId, timeout = this.timeout) {
 		await this.page.waitForFunction(
 			(expectedPeerId) =>

--- a/e2e/remote/collab01-scenario.mjs
+++ b/e2e/remote/collab01-scenario.mjs
@@ -118,29 +118,9 @@ export async function runCollab01RemoteScenario({
 		result.agents.a = webRTCObservation.diagnosticsA;
 		result.agents.b = webRTCObservation.diagnosticsB;
 
-		result.orbitdbBeforeReload = {
+		result.orbitdbSync = {
 			agentA: result.agents.a,
 			agentB: result.agents.b
-		};
-		result.reload = await agentB.reloadAndEnsureDatabase(result.agents.a.databaseAddress);
-		result.agents.b = result.reload.diagnostics;
-		if (result.agents.b.databaseAddress !== result.agents.a.databaseAddress) {
-			throw new Error("Agent B did not reopen Agent A's database after reload.");
-		}
-		if (process.env.REQUIRE_PUBLIC_RELAY === 'true') {
-			result.agents.b = await agentB.waitForPublicRelayConnection();
-		}
-		const webRTCAfterReload = await waitForWebRTCPeerConnection(
-			agentA,
-			agentB,
-			result.agents.a.peerId,
-			result.agents.b.peerId,
-			60_000
-		);
-		result.directConnectionAfterReload = {
-			transport: 'webrtc',
-			observedBy: webRTCAfterReload.observedBy,
-			...webRTCAfterReload.connection
 		};
 
 		const peerObservations = await Promise.allSettled([
@@ -151,7 +131,7 @@ export async function runCollab01RemoteScenario({
 			agentA.diagnostics(),
 			agentB.diagnostics()
 		]);
-		result.orbitdbAfterReload = {
+		result.orbitdbPeers = {
 			agentARecognizedAgentB: peerObservations[0].status === 'fulfilled',
 			agentBRecognizedAgentA: peerObservations[1].status === 'fulfilled',
 			agentA: result.agents.a,

--- a/src/lib/db-actions.js
+++ b/src/lib/db-actions.js
@@ -172,7 +172,7 @@ export async function loadTodoDatabase(address) {
 		await loadTodos();
 		storeActiveTodoDatabaseAddress(getDatabaseAddress(loadedTodoDB) || normalizedAddress);
 
-		if (!openActiveTodoDatabase && previousTodoDB && previousTodoDB !== loadedTodoDB) {
+		if (previousTodoDB && previousTodoDB !== loadedTodoDB) {
 			await previousTodoDB.close?.();
 		}
 

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -170,33 +170,23 @@ async function stopP2P() {
 }
 
 /**
- * Replace OrbitDB when selecting another address. A fresh OrbitDB instance
- * avoids retaining cached databases and sync handlers from the previous
- * address while keeping the same Helia/libp2p node and browser identity.
+ * Open another database on the browser's long-lived OrbitDB instance.
+ * OrbitDB manages multiple database addresses internally; only the active
+ * Todo database changes here.
  *
  * @param {string} address
  */
 async function openActiveTodoDatabase(address) {
-	if (!orbitdb || !helia) {
+	if (!orbitdb) {
 		throw new Error('OrbitDB is not initialized yet.');
 	}
 
-	const previousOrbitDB = orbitdb;
-	orbitdb = null;
-	todoDB = null;
-	await previousOrbitDB.stop();
-
-	const nextOrbitDB = await createOrbitDB({
-		ipfs: helia,
-		id: getOrCreateOrbitDBIdentityId()
-	});
-	const loadedTodoDB = await nextOrbitDB.open(address, {
+	const loadedTodoDB = await orbitdb.open(address, {
 		type: 'keyvalue',
 		sync: true
 	});
-	orbitdb = nextOrbitDB;
 	todoDB = loadedTodoDB;
-	return { orbitdb: nextOrbitDB, todoDB: loadedTodoDB };
+	return { orbitdb, todoDB: loadedTodoDB };
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep one long-lived OrbitDB instance per browser, matching OrbitDB core and orbitdb-relay
- open new Todo database addresses on that instance and close only the previously active database
- remove the fresh-OrbitDB experiment
- remove the ineffective page reload from local and remote collaboration scenarios
- retain strict active address, pubsub topic, and heads protocol verification

## Local verification
- pnpm run check
- pnpm run test:unit (2 passed)
- pnpm exec playwright test e2e/collaboration.spec.js --project=chromium (4 passed)