### PR TITLE
test: verify preexisting remote OrbitDB history

### DIFF
--- a/e2e/collaboration.spec.js
+++ b/e2e/collaboration.spec.js
@@ -56,6 +56,7 @@ test.describe.serial('Todo collaboration', () => {
 	/** @type {Awaited<ReturnType<typeof createAliceAndBob>> | null} */
 	let session = null;
 	const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	const existingAliceTodo = `alice-${runId}-existing-before-address-exchange`;
 	const bobTodoInAliceDb = `bob-${runId}-todo-in-alice-db`;
 	const aliceTodoInBobDb = `alice-${runId}-todo-in-bob-db`;
 	let aliceDefaultTodoDbAddress = '';
@@ -108,11 +109,13 @@ test.describe.serial('Todo collaboration', () => {
 		await waitForConnectedPeer(bob, alicePeerId, 'Bob -> Alice');
 		await waitForConnectedPeer(alice, bobPeerId, 'Alice -> Bob');
 		await waitForConnectionCount(bob, 2);
+		await addTodo(alice, existingAliceTodo);
 		await loadTodoDb(bob, aliceDefaultTodoDbAddress);
 		await Promise.all([
 			waitForOrbitDBPeer(alice, bobPeerId, 'Alice OrbitDB sync -> Bob'),
 			waitForOrbitDBPeer(bob, alicePeerId, 'Bob OrbitDB sync -> Alice')
 		]);
+		await expectTodoWithReplicationPoll(bob, existingAliceTodo);
 		await addTodo(bob, bobTodoInAliceDb);
 		await expectTodoWithReplicationPoll(alice, bobTodoInAliceDb);
 	});

--- a/e2e/remote/collab01-scenario.mjs
+++ b/e2e/remote/collab01-scenario.mjs
@@ -57,7 +57,8 @@ export async function runCollab01RemoteScenario({
 	remoteProvider = 'local'
 }) {
 	const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-	const todoFromA = `remote-${runId}-from-a`;
+	const existingTodoFromA = `remote-${runId}-existing-from-a`;
+	const liveTodoFromA = `remote-${runId}-live-from-a`;
 	const todoFromB = `remote-${runId}-from-b`;
 	const agentA = new TodoBrowserAgent('github-local', browserA, appUrl);
 	const agentB = new TodoBrowserAgent('testingbot-remote', browserB, appUrl);
@@ -94,16 +95,13 @@ export async function runCollab01RemoteScenario({
 			}
 		}
 
-		result.databaseExchange = {
-			source: 'agent-a',
-			address: result.agents.a.databaseAddress,
-			target: 'agent-b'
+		await agentA.createTodo(existingTodoFromA);
+		result.preexistingEntry = {
+			createdBy: 'agent-a',
+			text: existingTodoFromA,
+			databaseAddress: result.agents.a.databaseAddress
 		};
-		await agentB.openDatabase(result.agents.a.databaseAddress);
-		result.agents.b = await agentB.diagnostics();
-		if (result.agents.b.databaseAddress !== result.agents.a.databaseAddress) {
-			throw new Error("Agent B did not open Agent A's database through the collab01 UI.");
-		}
+
 		const webRTCObservation = await waitForWebRTCPeerConnection(
 			agentA,
 			agentB,
@@ -117,6 +115,19 @@ export async function runCollab01RemoteScenario({
 		};
 		result.agents.a = webRTCObservation.diagnosticsA;
 		result.agents.b = webRTCObservation.diagnosticsB;
+
+		result.databaseExchange = {
+			source: 'agent-a',
+			address: result.agents.a.databaseAddress,
+			target: 'agent-b'
+		};
+		await agentB.openDatabase(result.agents.a.databaseAddress);
+		result.agents.b = await agentB.diagnostics();
+		if (result.agents.b.databaseAddress !== result.agents.a.databaseAddress) {
+			throw new Error("Agent B did not open Agent A's database through the collab01 UI.");
+		}
+		await agentB.waitForTodo(existingTodoFromA);
+		result.replication.preexistingAToB = true;
 
 		result.orbitdbSync = {
 			agentA: result.agents.a,
@@ -150,8 +161,8 @@ export async function runCollab01RemoteScenario({
 		result.replication.bToAMs = Date.now() - bToAStarted;
 
 		const aToBStarted = Date.now();
-		await agentA.createTodo(todoFromA);
-		await agentB.waitForTodo(todoFromA);
+		await agentA.createTodo(liveTodoFromA);
+		await agentB.waitForTodo(liveTodoFromA);
 		result.replication.aToBMs = Date.now() - aToBStarted;
 		result.passed = true;
 		if (remoteProvider === 'testingbot') {


### PR DESCRIPTION
## Summary
- create an Alice entry before sharing her OrbitDB address
- establish relay and direct WebRTC connectivity before Bob opens Alice's database
- prove Bob receives Alice's existing history
- then prove live Bob-to-Alice and Alice-to-Bob replication

## Local verification
- pnpm run check
- pnpm run test:unit (2 passed)
- pnpm exec playwright test e2e/collaboration.spec.js --project=chromium (4 passed; relay observed two records)