### PR TITLE
test: prefer IPv4 for relay REST checks

### DIFF
--- a/e2e/remote/collab01-scenario.mjs
+++ b/e2e/remote/collab01-scenario.mjs
@@ -1,5 +1,21 @@
 import { mkdir, writeFile } from 'node:fs/promises';
+import { setDefaultResultOrder } from 'node:dns';
 import { TodoBrowserAgent } from './agent.mjs';
+
+setDefaultResultOrder('ipv4first');
+
+function serializeError(error) {
+	if (!error || typeof error !== 'object') return { message: String(error) };
+	return {
+		name: error.name ?? null,
+		message: error.message ?? String(error),
+		code: error.code ?? null,
+		syscall: error.syscall ?? null,
+		address: error.address ?? null,
+		port: error.port ?? null,
+		cause: error.cause ? serializeError(error.cause) : null
+	};
+}
 
 function hasPublicRelayConnection(diagnostics) {
 	return diagnostics.connections.some(({ remoteAddr }) =>
@@ -86,7 +102,7 @@ async function syncDatabaseThroughRelay(diagnostics, databaseAddress) {
 		} catch (error) {
 			attempts.push({
 				...candidate,
-				error: error instanceof Error ? error.message : String(error)
+				error: serializeError(error)
 			});
 		}
 	}


### PR DESCRIPTION
## Summary
- prefer IPv4 DNS results for coordinator-side relay REST requests
- preserve nested fetch causes including error code, syscall, address and port
- do not retry the health endpoint

## Local verification
- pnpm run check
- pnpm run test:unit (2 passed)
- pnpm exec playwright test e2e/collaboration.spec.js --project=chromium (4 passed)