### PR TITLE
Stabilize remote OrbitDB address switching

### DIFF
--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -80,6 +80,14 @@ export class TodoBrowserAgent {
 	async openDatabase(address) {
 		const input = this.page.getByTestId('load-todo-db-input');
 		await input.fill(address);
+		// TestingBot's remote `fill` can update the DOM property without making the
+		// Svelte binding observe the final value. Dispatch the browser event that
+		// the component uses for bind:value before clicking the load button.
+		await input.evaluate((element, value) => {
+			element.value = value;
+			element.dispatchEvent(new Event('input', { bubbles: true }));
+		}, address);
+		await expect(input).toHaveValue(address, { timeout: this.timeout });
 		await this.page.getByTestId('load-todo-db-button').click();
 		await this.page.waitForFunction(
 			(expectedAddress) => {


### PR DESCRIPTION
## Summary
- explicitly dispatch the bubbling input event used by Svelte bind:value
- verify the expected address is visible before submitting
- prevent TestingBot from displaying Alice's address while accidentally reopening Bob's previous database

## Evidence
Run 29186385721 showed the visible input contained Alice's address while the transition reopened Bob's old address. The focused runner now switches Bob to Alice's exact address; the remaining history timeout was traced to the old public relay and orbitdb-relay 0.9.5 has now been deployed.