### PR TITLE
fix(e2e): match relay bootstrap registration by instance name or hash

### DIFF
--- a/.github/workflows/relay-button-e2e.yml
+++ b/.github/workflows/relay-button-e2e.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble
-    timeout-minutes: 35
+    timeout-minutes: 40
     env:
       RELAY_BUTTON_E2E_PRIVATE_KEY: ${{ secrets.RELAY_BUTTON_E2E_PRIVATE_KEY }}
       RELAY_BUTTON_E2E_SSH_PUBLIC_KEY: ${{ vars.RELAY_BUTTON_E2E_SSH_PUBLIC_KEY }}

--- a/e2e/relay-button-provisioning.spec.js
+++ b/e2e/relay-button-provisioning.spec.js
@@ -66,7 +66,13 @@ async function injectWallet(context) {
 	});
 }
 
-async function waitForBootstrapRegistration({ page, ownerAddress, instanceHash, startedAt }) {
+async function waitForBootstrapRegistration({
+	page,
+	ownerAddress,
+	instanceName,
+	instanceHash,
+	startedAt
+}) {
 	const deadline = Date.now() + PROVISION_TIMEOUT;
 	let lastSummary = 'No bootstrap posts returned.';
 
@@ -90,18 +96,19 @@ async function waitForBootstrapRegistration({ page, ownerAddress, instanceHash, 
 		});
 		const registration = posts.find(({ address, content }) => {
 			const owner = (content?.ownerAddress ?? content?.publisherAddress ?? address)?.toLowerCase();
+			const registrationId = content?.registrationId ?? '';
 			const addresses = content?.browserMultiaddrs?.length
 				? content.browserMultiaddrs
 				: content?.multiaddrs;
 			return (
 				owner === ownerAddress.toLowerCase() &&
-				content?.registrationId?.includes(instanceHash) &&
+				(registrationId.includes(instanceName) || registrationId.includes(instanceHash)) &&
 				Number(content?.updatedAt ?? 0) >= startedAt - 60_000 &&
 				(addresses?.length ?? 0) > 0
 			);
 		});
 		if (registration) return registration;
-		lastSummary = `${posts.length} posts checked; no current registration for ${instanceHash}.`;
+		lastSummary = `${posts.length} posts checked; no current registration for ${instanceName} (${instanceHash}).`;
 		await new Promise((resolve) => setTimeout(resolve, 10_000));
 	}
 
@@ -309,6 +316,7 @@ test.describe('Sponsor Relay button', () => {
 			const registration = await waitForBootstrapRegistration({
 				page: deploymentPage,
 				ownerAddress: account.address,
+				instanceName,
 				instanceHash,
 				startedAt
 			});


### PR DESCRIPTION
Since relay-button 0.6.30 the guest VM publishes its bootstrap registration as relay:<profile>:<name> (it cannot embed its own instance item hash), so matching registrationId by instanceHash alone never succeeds and the test burns the full 20-minute PROVISION_TIMEOUT (runs #28, #29, #35). Ports the matcher from collab01 (d7f6f37): accept instanceName or instanceHash, mirroring the testkit's :<instanceName>: matching.

Also raise the job timeout to 40 minutes so a 30-minute test timeout still uploads evidence instead of being hard-cancelled (runs #32/#33).