### PR TITLE
feat(e2e): stream live progress and browser diagnostics in remote rep…

### DIFF
--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -1,5 +1,10 @@
 const DEFAULT_TIMEOUT = 120_000;
 
+/** Timestamped live progress line so CI logs show what remote runs are doing. */
+export function remoteProgress(message) {
+	console.log(`[remote-e2e ${new Date().toISOString()}] ${message}`);
+}
+
 export class TodoBrowserAgent {
 	constructor(name, browser, appUrl, timeout = DEFAULT_TIMEOUT) {
 		this.name = name;
@@ -16,16 +21,27 @@ export class TodoBrowserAgent {
 		this.page = await this.context.newPage();
 		this.page.on('console', (message) => {
 			const text = message.text();
-			if (
-				!/(todo|orbitdb|database peer|entry updated|connect|dial|relay|tls|websocket|pinning)/i.test(
+			const type = message.type();
+			const relevant =
+				/(todo|orbitdb|database peer|entry updated|connect|dial|relay|tls|websocket|pinning)/i.test(
 					text
-				)
-			) {
+				);
+			if (!relevant && type !== 'error' && type !== 'warning') {
 				return;
 			}
-			this.log.push(`[${message.type()}] ${text}`);
+			this.log.push(`[${type}] ${text}`);
 			if (this.log.length > 200) this.log.shift();
+			// Stream warnings/errors and relay-related lines live into the CI log:
+			// buried browser console output (e.g. TooManyOutboundProtocolStreams
+			// during relay pings) has repeatedly been the actual root cause.
+			if (type === 'error' || type === 'warning' || /relay|dial|connect/i.test(text)) {
+				remoteProgress(`[${this.name} ${type}] ${text.slice(0, 400)}`);
+			}
 		});
+		this.page.on('pageerror', (error) => {
+			remoteProgress(`[${this.name} pageerror] ${error.message}`);
+		});
+		remoteProgress(`[${this.name}] opening ${this.appUrl}...`);
 		await this.page.goto(this.appUrl, { waitUntil: 'domcontentloaded', timeout: this.timeout });
 
 		const modal = this.page.locator('div.fixed.inset-0.z-50');

--- a/e2e/remote/main-scenario.mjs
+++ b/e2e/remote/main-scenario.mjs
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from 'node:fs/promises';
-import { TodoBrowserAgent } from './agent.mjs';
+import { TodoBrowserAgent, remoteProgress } from './agent.mjs';
 
 function hasPublicRelayConnection(diagnostics) {
 	return diagnostics.connections.some(({ remoteAddr }) =>
@@ -46,14 +46,18 @@ export async function runMainRemoteScenario({
 	const agentB = new TodoBrowserAgent(`${remoteProvider}-remote`, browserB, appUrl);
 	const result = { runId, appUrl, agents: {}, replication: {}, evidence: {}, passed: false };
 	result.evidence.remoteProvider = { name: remoteProvider, ...remoteEvidence };
-	result.evidence.stage = 'opening-browsers';
 	const requirePublicRelay = process.env.REQUIRE_PUBLIC_RELAY === 'true';
+	const setStage = (stage, detail = '') => {
+		result.evidence.stage = stage;
+		remoteProgress(`stage: ${stage}${detail ? ` (${detail})` : ''}`);
+	};
+	setStage('opening-browsers', `provider=${remoteProvider}, requirePublicRelay=${requirePublicRelay}`);
 
 	await mkdir(outputDir, { recursive: true });
 
 	try {
 		await Promise.all([agentA.open(), agentB.open()]);
-		result.evidence.stage = 'verifying-relays';
+		setStage('verifying-relays');
 		if (requirePublicRelay) {
 			const [relayOptionsA, relayOptionsB] = await Promise.all([
 				agentA.waitForReachableRelayOptions(),
@@ -63,18 +67,26 @@ export async function runMainRemoteScenario({
 				agentA: relayOptionsA,
 				agentB: relayOptionsB
 			};
+			remoteProgress(
+				`relay options: agentA=[${relayOptionsA.map(({ label }) => label).join(', ')}] agentB=[${relayOptionsB.map(({ label }) => label).join(', ')}]`
+			);
+			remoteProgress('waiting for a public relay connection on both browsers...');
 			await Promise.all([
 				agentA.waitForPublicRelayConnection(),
 				agentB.waitForPublicRelayConnection()
 			]);
 		}
+		remoteProgress('waiting for dialable peer addresses on both browsers...');
 		await Promise.all([
 			agentA.waitForDialAddress({ requirePublic: requirePublicRelay }),
 			agentB.waitForDialAddress({ requirePublic: requirePublicRelay })
 		]);
 		result.agents.a = await agentA.diagnostics();
 		result.agents.b = await agentB.diagnostics();
-		result.evidence.stage = 'validating-shared-database';
+		remoteProgress(
+			`peers: agentA=${result.agents.a.peerId} (${result.agents.a.connections.length} connections), agentB=${result.agents.b.peerId} (${result.agents.b.connections.length} connections)`
+		);
+		setStage('validating-shared-database');
 
 		if (
 			!result.agents.a.databaseAddress ||
@@ -102,8 +114,9 @@ export async function runMainRemoteScenario({
 				`Agent B did not advertise a public dial address for ${result.agents.b.peerId}.`
 			);
 		}
+		remoteProgress(`agent A dialing agent B via ${addressForB}`);
 		await agentA.connectToMultiaddr(addressForB);
-		result.evidence.stage = 'connecting-browser-peers';
+		setStage('connecting-browser-peers');
 		await Promise.all([
 			agentA.waitForPeerConnection(result.agents.b.peerId),
 			agentB.waitForPeerConnection(result.agents.a.peerId)
@@ -112,21 +125,23 @@ export async function runMainRemoteScenario({
 		result.agents.a = await agentA.diagnostics();
 		result.agents.b = await agentB.diagnostics();
 
-		result.evidence.stage = 'creating-todo-on-agent-a';
+		setStage('creating-todo-on-agent-a');
 		const aToBStarted = Date.now();
 		await agentA.createTodo(todoFromA);
-		result.evidence.stage = 'replicating-agent-a-to-agent-b';
+		setStage('replicating-agent-a-to-agent-b');
 		await agentB.waitForTodo(todoFromA);
 		result.replication.aToBMs = Date.now() - aToBStarted;
+		remoteProgress(`replicated A -> B in ${result.replication.aToBMs} ms`);
 
 		const bToAStarted = Date.now();
-		result.evidence.stage = 'creating-todo-on-agent-b';
+		setStage('creating-todo-on-agent-b');
 		await agentB.createTodo(todoFromB);
-		result.evidence.stage = 'replicating-agent-b-to-agent-a';
+		setStage('replicating-agent-b-to-agent-a');
 		await agentA.waitForTodo(todoFromB);
 		result.replication.bToAMs = Date.now() - bToAStarted;
+		remoteProgress(`replicated B -> A in ${result.replication.bToAMs} ms`);
 		result.passed = true;
-		result.evidence.stage = 'completed';
+		setStage('completed');
 		await Promise.all([
 			agentA.screenshot(`${outputDir}/agent-a-success.png`),
 			agentB.screenshot(`${outputDir}/agent-b-success.png`)
@@ -141,6 +156,7 @@ export async function runMainRemoteScenario({
 		if (diagnosticsA.status === 'fulfilled') result.agents.a = diagnosticsA.value;
 		if (diagnosticsB.status === 'fulfilled') result.agents.b = diagnosticsB.value;
 		result.error = error instanceof Error ? error.message : String(error);
+		remoteProgress(`FAILED at stage "${result.evidence.stage}": ${result.error}`);
 		await Promise.allSettled([
 			agentA.screenshot(`${outputDir}/agent-a-failure.png`),
 			agentB.screenshot(`${outputDir}/agent-b-failure.png`)


### PR DESCRIPTION
…lication runs

The remote-replication job failed with a bare exit 1 while the actual root cause (TooManyOutboundProtocolStreamsError during relay pings in the deployed app) was only visible in the buried result.json browser log. Apply the same observability pattern that cracked the provisioning E2E today:

- timestamped [remote-e2e] stage transitions with context (provider, relay options per agent, peer ids/connection counts, dial target, replication timings, failure stage + reason)
- browser console warnings/errors and relay/dial-related lines are streamed live into the CI log per agent (plus pageerrors) instead of only being buried in the artifact