### PR TITLE
chore(collab01): testkit + Aleph Phase-B remote replication

### DIFF
--- a/.github/workflows/aleph-playwright-janitor.yml
+++ b/.github/workflows/aleph-playwright-janitor.yml
@@ -1,0 +1,20 @@
+name: Aleph Playwright runner janitor
+
+on:
+  schedule:
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    # Pin to main: the previous pin to the temporary fix/guest-bootstrap-cleanup
+    # branch would break as soon as that branch is deleted.
+    uses: NiKrause/relay-button/.github/workflows/playwright-runner-janitor.yml@main
+    with:
+      repository_scope: NiKrause/simple-todo
+      ttl_ms: 3600000
+    secrets:
+      ALEPH_PRIVATE_KEY: ${{ secrets.ALEPH_PLAYWRIGHT_PRIVATE_KEY || secrets.RELAY_BUTTON_E2E_PRIVATE_KEY }}

--- a/.github/workflows/relay-button-e2e.yml
+++ b/.github/workflows/relay-button-e2e.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble
-    timeout-minutes: 35
+    timeout-minutes: 40
     env:
       RELAY_BUTTON_E2E_PRIVATE_KEY: ${{ secrets.RELAY_BUTTON_E2E_PRIVATE_KEY }}
       RELAY_BUTTON_E2E_SSH_PUBLIC_KEY: ${{ vars.RELAY_BUTTON_E2E_SSH_PUBLIC_KEY }}
@@ -36,7 +36,7 @@ jobs:
       - name: Require relay deployment credentials
         run: test -n "$RELAY_BUTTON_E2E_PRIVATE_KEY" && test -n "$RELAY_BUTTON_E2E_SSH_PUBLIC_KEY"
       - name: Provision relay and verify two-browser replication
-        run: pnpm exec playwright test e2e/relay-button-provisioning.spec.js --project=chromium --workers=1
+        run: pnpm exec playwright test e2e/relay-button-provisioning.spec.js --project=chromium --workers=1 --reporter=list
       - name: Write relay E2E job summary
         if: always()
         run: node scripts/write-relay-e2e-summary.mjs

--- a/.github/workflows/remote-replication.yml
+++ b/.github/workflows/remote-replication.yml
@@ -1,6 +1,17 @@
 name: Remote browser replication
 
 on:
+  workflow_call:
+    inputs:
+      app_url:
+        description: Public deployment URL produced by the calling workflow
+        required: true
+        type: string
+      provider:
+        description: Second browser provider
+        required: false
+        type: string
+        default: aleph
   workflow_dispatch:
     inputs:
       app_url:
@@ -12,9 +23,10 @@ on:
         required: true
         type: choice
         options:
+          - aleph
           - testingbot
           - local
-        default: testingbot
+        default: aleph
 
 permissions:
   contents: read
@@ -22,13 +34,21 @@ permissions:
 jobs:
   main-remote-replication:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 50
+    concurrency:
+      group: simple-todo-aleph-playwright-${{ github.ref }}
+      cancel-in-progress: false
     env:
       REMOTE_APP_URL: ${{ inputs.app_url }}
       REMOTE_PROVIDER: ${{ inputs.provider }}
       REQUIRE_PUBLIC_RELAY: 'true'
       TESTINGBOT_KEY: ${{ secrets.TESTINGBOT_KEY }}
       TESTINGBOT_SECRET: ${{ secrets.TESTINGBOT_SECRET }}
+      ALEPH_VM_PRIVATE_KEY: ${{ secrets.ALEPH_PLAYWRIGHT_PRIVATE_KEY || secrets.RELAY_BUTTON_E2E_PRIVATE_KEY }}
+      ALEPH_VM_API_HOSTS: https://api2.aleph.im,https://api.aleph.im
+      LE_SPACE_NODE_MODULE_PATH: /tmp/le-space-playwright-provider/node_modules/@le-space/node/index.js
+      LE_SPACE_CORE_MODULE_PATH: /tmp/le-space-playwright-provider/node_modules/@le-space/core/index.js
+      ALEPH_PLAYWRIGHT_REGION: DE-preferred
     steps:
       - uses: actions/checkout@v6
 
@@ -43,11 +63,98 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Install isolated Aleph deployment tooling
+        if: inputs.provider == 'aleph'
+        run: npm install --prefix /tmp/le-space-playwright-provider @le-space/node@0.6.30
+
+      - name: Create per-run SSH identity and browser secret
+        if: inputs.provider == 'aleph'
+        run: |
+          secret="$(openssl rand -hex 32)"
+          echo "::add-mask::$secret"
+          echo "ALEPH_PLAYWRIGHT_SECRET=$secret" >> "$GITHUB_ENV"
+          ssh-keygen -q -t ed25519 -N '' -f "$RUNNER_TEMP/aleph-playwright-id"
+          echo "ALEPH_PLAYWRIGHT_SSH_KEY=$RUNNER_TEMP/aleph-playwright-id" >> "$GITHUB_ENV"
+          echo "ALEPH_VM_SSH_PUBLIC_KEY=$(cat "$RUNNER_TEMP/aleph-playwright-id.pub")" >> "$GITHUB_ENV"
+
+      - name: Check Aleph credentials and credits
+        if: inputs.provider == 'aleph'
+        run: node scripts/check-aleph-playwright-preflight.mjs
+
+      - name: Deploy temporary Aleph Playwright VM
+        if: inputs.provider == 'aleph'
+        id: aleph-deploy
+        env:
+          ALEPH_VM_MODE: deploy
+          ALEPH_VM_PROFILE: playwright-runner-phase-a
+          ALEPH_VM_NAME: simple-todo-${{ github.run_id }}-${{ github.run_attempt }}
+          ALEPH_VM_ROOTFS_MANIFEST_URL: https://raw.githubusercontent.com/NiKrause/simple-todo/main/static/rootfs-manifest.json
+          ALEPH_VM_VCPUS: '2'
+          ALEPH_VM_MEMORY_MIB: '4096'
+          ALEPH_VM_PREFERRED_COUNTRY_CODE: DE
+          ALEPH_VM_CHANNEL: TEST
+          ALEPH_VM_AUTO_CONFIGURE: 'false'
+          ALEPH_VM_VERIFY_REACHABILITY: 'false'
+          ALEPH_VM_PRESERVE_FAILED_DEPLOYMENT: 'false'
+        run: node scripts/run-aleph-playwright-deploy.mjs
+
+      - name: Record Aleph runtime and endpoint
+        if: inputs.provider == 'aleph'
+        env:
+          ALEPH_DEPLOY_INSTANCE_HASH: ${{ steps.aleph-deploy.outputs.instance_item_hash }}
+          ALEPH_DEPLOY_HOST: ${{ steps.aleph-deploy.outputs.host_ipv4 }}
+          ALEPH_DEPLOY_PROXY_URL: ${{ steps.aleph-deploy.outputs.web_proxy_url }}
+          ALEPH_DEPLOY_MAPPED_PORTS_JSON: ${{ steps.aleph-deploy.outputs.mapped_ports_json }}
+          ALEPH_DEPLOY_CRN_HASH: ${{ steps.aleph-deploy.outputs.crn_hash }}
+          ALEPH_DEPLOY_CRN_NAME: ${{ steps.aleph-deploy.outputs.crn_name }}
+        run: node scripts/prepare-aleph-playwright-runtime.mjs
+
+      - name: Install and start Playwright 1.61.1 in the guest
+        if: inputs.provider == 'aleph'
+        env:
+          ALEPH_PLAYWRIGHT_TLS_CERT: ${{ runner.temp }}/aleph-playwright-runner.crt
+          ALEPH_PLAYWRIGHT_TLS_KEY: ${{ runner.temp }}/aleph-playwright-runner.key
+        run: |
+          openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
+            -subj '/CN=aleph-playwright-runner' \
+            -addext "subjectAltName=IP:$ALEPH_PLAYWRIGHT_HOST" \
+            -keyout "$ALEPH_PLAYWRIGHT_TLS_KEY" \
+            -out "$ALEPH_PLAYWRIGHT_TLS_CERT" 2>/dev/null
+          chmod 600 "$ALEPH_PLAYWRIGHT_TLS_KEY"
+          echo "NODE_EXTRA_CA_CERTS=$ALEPH_PLAYWRIGHT_TLS_CERT" >> "$GITHUB_ENV"
+          bash scripts/connect-aleph-playwright-runner.sh
+
+      - name: Wait for authenticated WSS proxy
+        if: inputs.provider == 'aleph'
+        run: |
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent --show-error \
+              --connect-timeout 5 --max-time 10 \
+              --cacert "$NODE_EXTRA_CA_CERTS" \
+              -H "Authorization: Bearer $ALEPH_PLAYWRIGHT_SECRET" \
+              "$ALEPH_PLAYWRIGHT_VERSION_URL" >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo 'Authenticated Aleph Playwright endpoint did not become ready.' >&2
+          exit 1
+
       - name: Install local Chromium
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run cross-network main replication
         run: pnpm run test:e2e:remote:main
+
+      - name: Collect Aleph guest logs on failure
+        if: failure() && inputs.provider == 'aleph'
+        run: bash scripts/collect-aleph-playwright-logs.sh
+
+      - name: Erase and forget exact Aleph INSTANCE
+        if: always() && inputs.provider == 'aleph'
+        env:
+          ALEPH_PLAYWRIGHT_INSTANCE_HASH: ${{ steps.aleph-deploy.outputs.instance_item_hash }}
+        run: node scripts/cleanup-aleph-playwright-runner.mjs
 
       - name: Upload remote replication evidence
         if: always()

--- a/e2e/relay-button-provisioning.spec.js
+++ b/e2e/relay-button-provisioning.spec.js
@@ -1,191 +1,45 @@
-import { expect, test } from '@playwright/test';
-import {
-	DEFAULT_ALEPH_BOOTSTRAP_POST_TYPE,
-	fetchAlephBootstrapPosts
-} from '@le-space/aleph-bootstrap';
+import { expect } from '@playwright/test';
 import { privateKeyToAccount } from 'viem/accounts';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
+import {
+	createRelayTest,
+	createRelayEvidence,
+	updateRelayEvidenceStep,
+	writeRelayEvidence,
+	installEip1193WalletMock
+} from '@le-space/playwright';
 import { TodoBrowserAgent } from './remote/agent.mjs';
 import { selectPeerDialAddress } from './remote/main-scenario.mjs';
 import { generateSpanishMnemonic } from '../src/lib/spanish-mnemonic.js';
 
+// Chapter (collab01): provisions a real relay through the Relay Button UI and
+// replicates a Spanish-mnemonic-named shared OrbitDB list between two browsers.
+// All relay-lifecycle plumbing (wallet mock, deploy → instance → bootstrap
+// registration, browser-dialable address selection, CRN erase + Aleph FORGET
+// cleanup) comes from the shared @le-space/playwright test kit; the shared-list
+// mnemonic flow and the optional relay /health check stay here (issue #29).
+
 const PRIVATE_KEY = process.env.RELAY_BUTTON_E2E_PRIVATE_KEY?.trim();
+const SSH_PUBLIC_KEY = process.env.RELAY_BUTTON_E2E_SSH_PUBLIC_KEY?.trim();
 const APP_URL = process.env.RELAY_BUTTON_E2E_APP_URL ?? 'http://localhost:4173';
 const OUTPUT_DIR = 'test-results/relay-button';
 const PROVISION_TIMEOUT = 20 * 60_000;
+const REGISTRATION_TIMEOUT = 15 * 60_000;
 const RELAY_HEALTH_TIMEOUT = 60_000;
-const REPLICATION_TIMEOUT = 3 * 60_000;
+const RELAY_READINESS_TIMEOUT = 10 * 60_000;
 const RELAY_DIAL_ATTEMPT_TIMEOUT = 20_000;
-const RELAY_READINESS_TIMEOUT = 8 * 60_000;
-const TEST_SSH_PUBLIC_KEY = process.env.RELAY_BUTTON_E2E_SSH_PUBLIC_KEY?.trim();
+const REPLICATION_TIMEOUT = 3 * 60_000;
 
-function installWalletProvider(context, account) {
-	return context.exposeBinding(
-		'__relayE2eWalletRequest',
-		async (_source, { method, params = [] }) => {
-			switch (method) {
-				case 'eth_requestAccounts':
-				case 'eth_accounts':
-					return [account.address];
-				case 'eth_chainId':
-					return '0x1';
-				case 'personal_sign': {
-					const payload = params.find(
-						(value) =>
-							typeof value === 'string' &&
-							value.startsWith('0x') &&
-							value.toLowerCase() !== account.address.toLowerCase()
-					);
-					if (!payload) throw new Error('personal_sign did not contain a hex payload.');
-					return account.signMessage({ message: { raw: payload } });
-				}
-				default:
-					throw new Error(`Unsupported E2E wallet method: ${method}`);
-			}
-		}
-	);
+/**
+ * Live progress logging: Playwright shows no output between test start and
+ * finish, so a 12-30 minute provisioning run looks frozen in CI logs.
+ */
+function progress(message) {
+	console.log(`[relay-e2e ${new Date().toISOString()}] ${message}`);
 }
 
-async function injectWallet(context) {
-	await context.addInitScript(() => {
-		const listeners = new Map();
-		Object.defineProperty(window, 'ethereum', {
-			configurable: true,
-			value: {
-				isMetaMask: true,
-				request: (request) => window.__relayE2eWalletRequest(request),
-				on(event, listener) {
-					const eventListeners = listeners.get(event) ?? new Set();
-					eventListeners.add(listener);
-					listeners.set(event, eventListeners);
-				},
-				removeListener(event, listener) {
-					listeners.get(event)?.delete(listener);
-				}
-			}
-		});
-	});
-}
-
-async function waitForBootstrapRegistration({
-	page,
-	ownerAddress,
-	instanceName,
-	instanceHash,
-	startedAt
-}) {
-	const deadline = Date.now() + PROVISION_TIMEOUT;
-	let lastSummary = 'No bootstrap posts returned.';
-
-	while (Date.now() < deadline) {
-		const deploymentFailure = await page.evaluate(() => {
-			const error = document.querySelector('aside.panel .alert.error')?.textContent?.trim();
-			const status = document.querySelector('aside.panel .status-text')?.textContent?.trim();
-			if (error) return error;
-			if (status === 'Deployment failed') return status;
-			return null;
-		});
-		if (deploymentFailure) {
-			throw new Error(`Relay Button deployment failed: ${deploymentFailure}`);
-		}
-		const posts = await fetchAlephBootstrapPosts({
-			pagination: 200,
-			postType: DEFAULT_ALEPH_BOOTSTRAP_POST_TYPE
-		}).catch((error) => {
-			lastSummary = error instanceof Error ? error.message : String(error);
-			return [];
-		});
-		const registration = posts.find(({ address, content }) => {
-			const owner = (content?.ownerAddress ?? content?.publisherAddress ?? address)?.toLowerCase();
-			const registrationId = content?.registrationId ?? '';
-			const addresses = content?.browserMultiaddrs?.length
-				? content.browserMultiaddrs
-				: content?.multiaddrs;
-			return (
-				owner === ownerAddress.toLowerCase() &&
-				(registrationId.includes(instanceName) || registrationId.includes(instanceHash)) &&
-				Number(content?.updatedAt ?? 0) >= startedAt - 60_000 &&
-				(addresses?.length ?? 0) > 0
-			);
-		});
-		if (registration) return registration;
-		lastSummary = `${posts.length} posts checked; no current registration for ${instanceName} (${instanceHash}).`;
-		await new Promise((resolve) => setTimeout(resolve, 10_000));
-	}
-
-	throw new Error(`Relay bootstrap registration timed out. ${lastSummary}`);
-}
-
-async function waitForDeploymentInstance(page, instanceName) {
-	const outcome = await page.waitForFunction(
-		(expectedName) => {
-			const instance = [...document.querySelectorAll('details')].find((element) =>
-				element.textContent?.includes(expectedName)
-			);
-			if (instance) return { status: 'instance' };
-			const error = document.querySelector('aside.panel .alert.error');
-			if (error?.textContent?.trim()) return { status: 'error', message: error.textContent.trim() };
-			const status = document.querySelector('aside.panel .status-text')?.textContent?.trim();
-			if (status === 'Deployment failed') return { status: 'error', message: status };
-			return null;
-		},
-		instanceName,
-		{ timeout: PROVISION_TIMEOUT, polling: 500 }
-	);
-	const result = await outcome.jsonValue();
-	if (result?.status === 'error') {
-		throw new Error(`Relay Button deployment failed: ${result.message}`);
-	}
-	const instance = page.locator('details').filter({ hasText: instanceName }).first();
-	const apiHref = await instance
-		.getByRole('link', { name: 'API', exact: true })
-		.getAttribute('href');
-	const instanceHash = apiHref?.match(/\/messages\/([^/?#]+)/)?.[1];
-	if (!instanceHash) throw new Error(`Could not read the Aleph instance hash for ${instanceName}.`);
-	return { instance, instanceHash };
-}
-
-function selectBrowserRelayAddresses(content) {
-	const addresses = content.browserMultiaddrs?.length
-		? content.browserMultiaddrs
-		: (content.multiaddrs ?? []);
-	return addresses
-		.filter((address) => /\/(tls\/ws|wss)\/p2p\//.test(address))
-		.sort((left, right) => {
-			const rank = (address) =>
-				address.includes('.libp2p.direct/') ? 0 : address.includes('/dns4/') ? 1 : 2;
-			return rank(left) - rank(right);
-		});
-}
-
-async function connectBrowsersToRelay(agents, addresses, relayPeerId) {
-	const attempts = [];
-	const deadline = Date.now() + RELAY_READINESS_TIMEOUT;
-	while (Date.now() < deadline) {
-		for (const address of addresses) {
-			const dialResults = await Promise.allSettled(
-				agents.map((agent) => agent.connectToMultiaddr(address))
-			);
-			const results = await Promise.allSettled(
-				agents.map((agent) => agent.waitForPeerConnection(relayPeerId, RELAY_DIAL_ATTEMPT_TIMEOUT))
-			);
-			attempts.push({
-				at: new Date().toISOString(),
-				address,
-				dialSubmitted: dialResults.map(({ status }) => status === 'fulfilled'),
-				connected: results.map(({ status }) => status === 'fulfilled')
-			});
-			if (results.every(({ status }) => status === 'fulfilled')) return { address, attempts };
-			if (Date.now() >= deadline) break;
-		}
-		await new Promise((resolve) => setTimeout(resolve, 5_000));
-	}
-
-	throw new Error(
-		`Browsers did not connect to relay ${relayPeerId}. Attempts: ${JSON.stringify(attempts)}`
-	);
-}
-
+// Optional relay /health diagnostic over the published 2n6.me address — kept
+// from the collab01 chapter (the shared kit's provisionRelay does not probe it).
 async function waitForRelayHealth(address, expectedPeerId) {
 	const hostname = address.match(/\/dns[46]\/([^/]+)/)?.[1];
 	if (!hostname) throw new Error(`Cannot derive relay health URL from ${address}`);
@@ -211,250 +65,280 @@ async function waitForRelayHealth(address, expectedPeerId) {
 	throw new Error(`Relay health check failed at ${healthUrl}: ${lastError}`);
 }
 
-async function deleteProvisionedRelay(page, instanceName) {
-	if (!page || page.isClosed()) return;
-	await page
-		.getByRole('button', { name: 'Refresh' })
-		.click()
-		.catch(() => {});
-	const instance = page.locator('details').filter({ hasText: instanceName }).first();
-	await instance.waitFor({ state: 'visible', timeout: 60_000 });
-	await instance.getByRole('button', { name: 'Delete', exact: true }).click();
-	await expect(instance).toBeHidden({ timeout: 3 * 60_000 });
+// Dial BOTH browsers at each relay address concurrently and keep retrying until
+// both hold a connection to the relay peer, or the readiness window elapses.
+// Freshly provisioned relays can take minutes to become browser-dialable (guest
+// boot + AutoTLS), so both browsers share one window.
+async function connectBrowsersToRelay(agents, addresses, relayPeerId) {
+	const attempts = [];
+	const deadline = Date.now() + RELAY_READINESS_TIMEOUT;
+
+	while (Date.now() < deadline) {
+		for (const address of addresses) {
+			await Promise.allSettled(agents.map((agent) => agent.connectToMultiaddr(address)));
+			const results = await Promise.allSettled(
+				agents.map((agent) => agent.waitForPeerConnection(relayPeerId, RELAY_DIAL_ATTEMPT_TIMEOUT))
+			);
+			const connected = results.map(({ status }) => status === 'fulfilled');
+			attempts.push({ at: new Date().toISOString(), address, connected });
+			progress(`relay dial via ${address}: connected=[${connected.join(', ')}]`);
+			if (connected.every(Boolean)) return { address, attempts };
+			if (Date.now() >= deadline) break;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 5_000));
+	}
+
+	throw new Error(`browsers did not connect to relay ${relayPeerId}: ${JSON.stringify(attempts)}`);
 }
 
-test.describe('Relay Button', () => {
-	test.skip(!PRIVATE_KEY, 'RELAY_BUTTON_E2E_PRIVATE_KEY is required to provision an Aleph relay.');
-	test.skip(
-		!TEST_SSH_PUBLIC_KEY,
+// A placeholder key keeps the file collectable when credentials are absent:
+// createRelayTest must run at module scope to register the relayLifecycle
+// fixture, but the skips below stop the body from ever using this account.
+const RESOLVED_KEY = PRIVATE_KEY
+	? PRIVATE_KEY.startsWith('0x')
+		? PRIVATE_KEY
+		: `0x${PRIVATE_KEY}`
+	: `0x${'1'.repeat(64)}`;
+const account = privateKeyToAccount(RESOLVED_KEY);
+const sharedMnemonic = generateSpanishMnemonic();
+
+const evidence = createRelayEvidence({
+	instanceName: `simple-todo-e2e-${Date.now()}`,
+	ownerAddress: account.address,
+	steps: {
+		walletAndManifest: 'Wallet connected and relay manifest accepted',
+		instanceProvisioned: 'Aleph relay VM provisioned',
+		bootstrapPublished: 'Browser multiaddress published to Aleph',
+		healthVerified: 'Optional relay /health diagnostic checked',
+		browserAConnected: 'Browser A connected through custom multiaddress',
+		browserBConnected: 'Browser B connected through custom multiaddress',
+		sharedDatabase: 'Both browsers opened the same Spanish-mnemonic OrbitDB list',
+		browserPeersConnected: 'Browser-to-browser relay connection established',
+		replicationAToB: 'TODO replicated from browser A to browser B',
+		replicationBToA: 'TODO replicated from browser B to browser A',
+		cleanup: 'Temporary Aleph relay forgotten and deallocated'
+	}
+});
+evidence.sharedMnemonic = sharedMnemonic;
+
+const relayTest = createRelayTest({ account, evidence });
+
+relayTest.describe('Relay Button', () => {
+	relayTest.skip(
+		!PRIVATE_KEY,
+		'RELAY_BUTTON_E2E_PRIVATE_KEY is required to provision an Aleph relay.'
+	);
+	relayTest.skip(
+		!SSH_PUBLIC_KEY,
 		'RELAY_BUTTON_E2E_SSH_PUBLIC_KEY is required to provision an Aleph relay.'
 	);
-	test.setTimeout(30 * 60_000);
+	relayTest.setTimeout(30 * 60_000);
 
-	test('provisions a relay and replicates one mnemonic list between two browsers', async ({
-		browser
-	}) => {
-		await mkdir(OUTPUT_DIR, { recursive: true });
-		const account = privateKeyToAccount(
-			PRIVATE_KEY.startsWith('0x') ? PRIVATE_KEY : `0x${PRIVATE_KEY}`
-		);
-		const instanceName = `simple-todo-e2e-${Date.now()}`;
-		const sharedMnemonic = generateSpanishMnemonic();
-		const startedAt = Date.now();
-		const deploymentContext = await browser.newContext();
-		await installWalletProvider(deploymentContext, account);
-		await injectWallet(deploymentContext);
-		const deploymentPage = await deploymentContext.newPage();
-		const agentA = new TodoBrowserAgent('relay-e2e-a', browser, APP_URL, REPLICATION_TIMEOUT);
-		const agentB = new TodoBrowserAgent('relay-e2e-b', browser, APP_URL, REPLICATION_TIMEOUT);
-		let deployed = false;
-		let cleanupError = null;
-		let testError = null;
-		const evidence = {
-			instanceName,
-			sharedMnemonic,
-			ownerAddress: account.address,
-			startedAt: new Date(startedAt).toISOString(),
-			steps: {
-				walletAndManifest: {
-					label: 'Wallet connected and relay manifest accepted',
-					status: 'pending'
-				},
-				instanceProvisioned: { label: 'Aleph relay VM provisioned', status: 'pending' },
-				bootstrapPublished: { label: 'Browser multiaddress published to Aleph', status: 'pending' },
-				healthVerified: {
-					label: 'Optional relay /health diagnostic checked',
-					status: 'pending'
-				},
-				browserAConnected: {
-					label: 'Browser A connected through custom multiaddress',
-					status: 'pending'
-				},
-				browserBConnected: {
-					label: 'Browser B connected through custom multiaddress',
-					status: 'pending'
-				},
-				sharedDatabase: {
-					label: 'Both browsers opened the same Spanish-mnemonic OrbitDB list',
-					status: 'pending'
-				},
-				browserPeersConnected: {
-					label: 'Browser-to-browser relay connection established',
-					status: 'pending'
-				},
-				replicationAToB: {
-					label: 'TODO replicated from browser A to browser B',
-					status: 'pending'
-				},
-				replicationBToA: {
-					label: 'TODO replicated from browser B to browser A',
-					status: 'pending'
-				},
-				cleanup: { label: 'Temporary Aleph relay deleted', status: 'pending' }
-			}
-		};
-		const pass = (step, detail = '') => {
-			evidence.steps[step] = { ...evidence.steps[step], status: 'passed', detail };
-		};
-		const skip = (step, detail = '') => {
-			evidence.steps[step] = { ...evidence.steps[step], status: 'skipped', detail };
-		};
-
-		try {
-			await deploymentPage.goto(APP_URL, { waitUntil: 'domcontentloaded' });
-			const consentModal = deploymentPage.locator('div.fixed.inset-0.z-50');
-			await consentModal.waitFor({ state: 'visible', timeout: 15_000 });
-			for (const checkbox of await consentModal.locator('input[type="checkbox"]').all()) {
-				await checkbox.check();
-			}
-			await consentModal.getByTestId('shared-list-mnemonic-input').fill(sharedMnemonic);
-			await consentModal.getByRole('button', { name: 'Open shared list' }).click();
-			const relayLauncher = deploymentPage.getByRole('button', {
-				name: /^(?:Relay Button|Sponsor Relay)$/
+	relayTest(
+		'provisions a relay and replicates one mnemonic list between two browsers',
+		async ({ browser, relayLifecycle }) => {
+			await mkdir(OUTPUT_DIR, { recursive: true });
+			const instanceName = evidence.instanceName;
+			const startedAt = Date.now();
+			const deploymentContext = await browser.newContext();
+			await installEip1193WalletMock(deploymentContext, account);
+			// Enable @le-space/ui controller tracing so deploy-phase diagnostics
+			// reach the browser console, where the handler below forwards them.
+			await deploymentContext.addInitScript(() => {
+				try {
+					localStorage.setItem('LE_SPACE_UI_DEBUG', '1');
+				} catch {
+					// localStorage may be unavailable; tracing is best-effort.
+				}
 			});
-			await relayLauncher.waitFor({ state: 'visible', timeout: 15_000 });
-			await relayLauncher.click();
-			await deploymentPage.getByLabel('Instance Name').fill(instanceName);
-			await deploymentPage.getByText('Advanced', { exact: true }).click();
-			await deploymentPage.getByLabel('SSH Public Key').fill(TEST_SSH_PUBLIC_KEY);
-			await deploymentPage.getByRole('button', { name: 'Connect MetaMask' }).click();
-			const deployButton = deploymentPage.getByRole('button', { name: 'Deploy Relay' });
-			await expect(deployButton).toBeEnabled({ timeout: 120_000 });
-			pass('walletAndManifest');
-			await deployButton.click();
-			const { instanceHash } = await waitForDeploymentInstance(deploymentPage, instanceName);
-			deployed = true;
-			evidence.instanceHash = instanceHash;
-			pass('instanceProvisioned', instanceHash);
-
-			const registration = await waitForBootstrapRegistration({
-				page: deploymentPage,
-				ownerAddress: account.address,
-				instanceName,
-				instanceHash,
-				startedAt
+			const deploymentPage = await deploymentContext.newPage();
+			deploymentPage.on('console', (message) => {
+				const text = message.text();
+				if (
+					text.includes('[le-space/ui]') ||
+					message.type() === 'error' ||
+					message.type() === 'warning'
+				) {
+					progress(`[deploy-page ${message.type()}] ${text.slice(0, 500)}`);
+				}
 			});
-			const relayPeerId = registration.content.peerId;
-			const relayAddresses = selectBrowserRelayAddresses(registration.content);
-			expect(
-				relayAddresses,
-				'new relay must advertise a browser-reachable address'
-			).not.toHaveLength(0);
-			evidence.registration = registration;
-			evidence.relayAddresses = relayAddresses;
-			pass('bootstrapPublished', relayAddresses.join(', '));
-			const healthAddress = (registration.content.multiaddrs ?? []).find((address) =>
-				/\/dns[46]\/.*\.2n6\.me\/tcp\/443\/(tls\/ws|wss)\/p2p\//.test(address)
+			deploymentPage.on('pageerror', (error) =>
+				progress(`[deploy-page pageerror] ${error.message}`)
 			);
-			const healthPromise = healthAddress
-				? waitForRelayHealth(healthAddress, relayPeerId)
-						.then((health) => ({ health }))
-						.catch((error) => ({ error }))
-				: Promise.resolve({ error: new Error('No 2n6 health address was published.') });
 
-			await Promise.all([agentA.open(sharedMnemonic), agentB.open(sharedMnemonic)]);
-			const relayConnection = await connectBrowsersToRelay(
-				[agentA, agentB],
-				relayAddresses,
-				relayPeerId
-			);
-			evidence.relayAddress = relayConnection.address;
-			evidence.relayDialAttempts = relayConnection.attempts;
-			pass('browserAConnected', relayPeerId);
-			pass('browserBConnected', relayPeerId);
-			const healthResult = await healthPromise;
-			if ('health' in healthResult) {
-				evidence.health = healthResult.health;
-				pass('healthVerified', relayPeerId);
-			} else {
-				const detail =
-					healthResult.error instanceof Error
-						? healthResult.error.message
-						: String(healthResult.error);
-				evidence.healthWarning = detail;
-				skip('healthVerified', `Optional HTTP diagnostic unavailable: ${detail}`);
-			}
-
-			await Promise.all([agentA.waitForPublicDialAddress(), agentB.waitForPublicDialAddress()]);
-			const [diagnosticsA, diagnosticsB] = await Promise.all([
-				agentA.diagnostics(),
-				agentB.diagnostics()
-			]);
-			expect(diagnosticsA.databaseAddress).toBe(diagnosticsB.databaseAddress);
-			expect(diagnosticsA.databaseName).toBe(sharedMnemonic);
-			expect(diagnosticsB.databaseName).toBe(sharedMnemonic);
-			pass('sharedDatabase', `${sharedMnemonic}: ${diagnosticsA.databaseAddress}`);
-			const addressForB = selectPeerDialAddress(diagnosticsB, diagnosticsB.peerId, {
-				relayPeerId
-			});
-			expect(addressForB, 'browser B must advertise an address through the new relay').toBeTruthy();
-			await agentA.connectToMultiaddr(addressForB);
-			await Promise.all([
-				agentA.waitForPeerConnection(diagnosticsB.peerId),
-				agentB.waitForPeerConnection(diagnosticsA.peerId)
-			]);
-			pass('browserPeersConnected', `${diagnosticsA.peerId} ↔ ${diagnosticsB.peerId}`);
-
-			const todoA = `${instanceName}-from-a`;
-			const todoB = `${instanceName}-from-b`;
-			await agentA.createTodo(todoA);
-			await agentB.waitForTodo(todoA);
-			pass('replicationAToB', todoA);
-			await agentB.createTodo(todoB);
-			await agentA.waitForTodo(todoB);
-			pass('replicationBToA', todoB);
-			evidence.final = {
-				agentA: await agentA.diagnostics(),
-				agentB: await agentB.diagnostics(),
-				addressForB
+			const pass = (step, detail = '') => {
+				updateRelayEvidenceStep(evidence, step, 'passed', detail);
+				progress(`PASSED: ${evidence.steps[step].label}${detail ? ` (${detail})` : ''}`);
 			};
-			await Promise.all([
-				agentA.screenshot(`${OUTPUT_DIR}/browser-a.png`),
-				agentB.screenshot(`${OUTPUT_DIR}/browser-b.png`),
-				deploymentPage.screenshot({ path: `${OUTPUT_DIR}/relay-panel.png`, fullPage: true })
-			]);
-		} catch (error) {
-			testError = error instanceof Error ? error : new Error(String(error));
-			evidence.error = testError.message;
-			const [diagnosticsA, diagnosticsB] = await Promise.allSettled([
-				agentA.diagnostics(),
-				agentB.diagnostics()
-			]);
-			evidence.failureDiagnostics = {
-				agentA: diagnosticsA.status === 'fulfilled' ? diagnosticsA.value : null,
-				agentB: diagnosticsB.status === 'fulfilled' ? diagnosticsB.value : null
+			const skip = (step, detail = '') => {
+				updateRelayEvidenceStep(evidence, step, 'skipped', detail);
 			};
-			await Promise.allSettled([
-				deploymentPage.screenshot({
-					path: `${OUTPUT_DIR}/relay-panel-error.png`,
-					fullPage: true
-				}),
-				agentA.screenshot(`${OUTPUT_DIR}/browser-a-error.png`),
-				agentB.screenshot(`${OUTPUT_DIR}/browser-b-error.png`)
-			]);
-		}
 
-		await Promise.allSettled([agentA.close(), agentB.close()]);
-		if (deployed) {
+			const agentA = new TodoBrowserAgent('relay-e2e-a', browser, APP_URL, REPLICATION_TIMEOUT);
+			const agentB = new TodoBrowserAgent('relay-e2e-b', browser, APP_URL, REPLICATION_TIMEOUT);
+			let testError = null;
+
 			try {
-				await deleteProvisionedRelay(deploymentPage, instanceName);
-				pass('cleanup');
+				progress(
+					`starting relay provisioning E2E as ${account.address} (instance ${instanceName})`
+				);
+
+				// Chapter: pass the consent modal by opening the shared list named by
+				// the mnemonic — this gate must clear before the Relay Button appears.
+				await deploymentPage.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+				const consentModal = deploymentPage.locator('div.fixed.inset-0.z-50');
+				await consentModal.waitFor({ state: 'visible', timeout: 15_000 });
+				for (const checkbox of await consentModal.locator('input[type="checkbox"]').all()) {
+					await checkbox.check();
+				}
+				await consentModal.getByTestId('shared-list-mnemonic-input').fill(sharedMnemonic);
+				await consentModal.getByRole('button', { name: 'Open shared list' }).click();
+
+				// Phase 1: Wallet + manifest + provision (deploy → instance → bootstrap).
+				const relay = await relayLifecycle.provision(deploymentPage, {
+					instanceName,
+					sshPublicKey: SSH_PUBLIC_KEY,
+					startedAt,
+					provisionTimeoutMs: PROVISION_TIMEOUT,
+					registrationTimeoutMs: REGISTRATION_TIMEOUT,
+					onPhase: (phase, detail = '') =>
+						progress(`provision: ${phase}${detail ? ` (${detail})` : ''}`)
+				});
+				pass('walletAndManifest');
+				evidence.instanceHash = relay.instanceHash;
+				evidence.registration = relay.registration;
+				evidence.relayAddresses = relay.addresses;
+				pass('instanceProvisioned', relay.instanceHash);
+
+				const relayAddresses = relay.addresses;
+				expect(
+					relayAddresses,
+					'new relay must advertise a browser-reachable address'
+				).not.toHaveLength(0);
+				pass('bootstrapPublished', relayAddresses.join(', '));
+
+				// Chapter: optional /health diagnostic over the 2n6.me address.
+				const healthAddress = (relay.registration.content.multiaddrs ?? []).find((address) =>
+					/\/dns[46]\/.*\.2n6\.me\/tcp\/443\/(tls\/ws|wss)\/p2p\//.test(address)
+				);
+				const healthPromise = healthAddress
+					? waitForRelayHealth(healthAddress, relay.peerId)
+							.then((health) => ({ health }))
+							.catch((error) => ({ error }))
+					: Promise.resolve({ error: new Error('No 2n6 health address was published.') });
+
+				// Phase 2: Browser A + B open the shared mnemonic list and connect.
+				await Promise.all([agentA.open(sharedMnemonic), agentB.open(sharedMnemonic)]);
+				const relayConnection = await connectBrowsersToRelay(
+					[agentA, agentB],
+					relayAddresses,
+					relay.peerId
+				);
+				evidence.relayConnection = relayConnection;
+				pass('browserAConnected', relayConnection.address);
+				pass('browserBConnected', relayConnection.address);
+
+				const healthResult = await healthPromise;
+				if ('health' in healthResult) {
+					evidence.health = healthResult.health;
+					pass('healthVerified', relay.peerId);
+				} else {
+					const detail =
+						healthResult.error instanceof Error
+							? healthResult.error.message
+							: String(healthResult.error);
+					evidence.healthWarning = detail;
+					skip('healthVerified', `Optional HTTP diagnostic unavailable: ${detail}`);
+				}
+
+				// Phase 3: Same Spanish-mnemonic OrbitDB list + a direct dial.
+				await Promise.all([agentA.waitForPublicDialAddress(), agentB.waitForPublicDialAddress()]);
+				const [diagnosticsA, diagnosticsB] = await Promise.all([
+					agentA.diagnostics(),
+					agentB.diagnostics()
+				]);
+				expect(diagnosticsA.databaseAddress).toBe(diagnosticsB.databaseAddress);
+				expect(diagnosticsA.databaseName).toBe(sharedMnemonic);
+				expect(diagnosticsB.databaseName).toBe(sharedMnemonic);
+				pass('sharedDatabase', `${sharedMnemonic}: ${diagnosticsA.databaseAddress}`);
+
+				const addressForB = selectPeerDialAddress(diagnosticsB, diagnosticsB.peerId, {
+					relayPeerId: relay.peerId
+				});
+				expect(
+					addressForB,
+					'browser B must advertise an address through the new relay'
+				).toBeTruthy();
+				await agentA.connectToMultiaddr(addressForB);
+				await Promise.all([
+					agentA.waitForPeerConnection(diagnosticsB.peerId),
+					agentB.waitForPeerConnection(diagnosticsA.peerId)
+				]);
+				pass('browserPeersConnected', `${diagnosticsA.peerId} ↔ ${diagnosticsB.peerId}`);
+
+				// Phase 4: Bidirectional OrbitDB replication of the shared list.
+				const todoA = `${instanceName}-from-a`;
+				const todoB = `${instanceName}-from-b`;
+				await agentA.createTodo(todoA);
+				await agentB.waitForTodo(todoA);
+				pass('replicationAToB', todoA);
+				await agentB.createTodo(todoB);
+				await agentA.waitForTodo(todoB);
+				pass('replicationBToA', todoB);
+
+				evidence.final = {
+					agentA: await agentA.diagnostics(),
+					agentB: await agentB.diagnostics(),
+					relayAddresses,
+					addressForB
+				};
+				await Promise.all([
+					agentA.screenshot(`${OUTPUT_DIR}/browser-a.png`),
+					agentB.screenshot(`${OUTPUT_DIR}/browser-b.png`),
+					deploymentPage.screenshot({ path: `${OUTPUT_DIR}/relay-panel.png`, fullPage: true })
+				]);
 			} catch (error) {
-				cleanupError = error instanceof Error ? error : new Error(String(error));
-				evidence.steps.cleanup.status = 'failed';
-				evidence.steps.cleanup.detail = cleanupError.message;
+				testError = error instanceof Error ? error : new Error(String(error));
+				evidence.error = testError.message;
+				progress(`FAILED: ${testError.message}`);
+				const [diagnosticsA, diagnosticsB] = await Promise.allSettled([
+					agentA.diagnostics(),
+					agentB.diagnostics()
+				]);
+				evidence.failureDiagnostics = {
+					agentA: diagnosticsA.status === 'fulfilled' ? diagnosticsA.value : null,
+					agentB: diagnosticsB.status === 'fulfilled' ? diagnosticsB.value : null
+				};
+				await Promise.allSettled([
+					deploymentPage.screenshot({
+						path: `${OUTPUT_DIR}/relay-panel-error.png`,
+						fullPage: true
+					}),
+					agentA.screenshot(`${OUTPUT_DIR}/browser-a-error.png`),
+					agentB.screenshot(`${OUTPUT_DIR}/browser-b-error.png`)
+				]);
+			} finally {
+				await Promise.allSettled([agentA.close(), agentB.close()]);
+				try {
+					progress(`cleanup: erasing and forgetting ${instanceName}...`);
+					const results = await relayLifecycle.cleanupAll();
+					if (results.length === 0) {
+						updateRelayEvidenceStep(evidence, 'cleanup', 'skipped', 'No VM was provisioned.');
+					} else {
+						pass('cleanup', results[0]?.verificationSummary ?? '');
+					}
+				} catch (cleanupError) {
+					const detail =
+						cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+					updateRelayEvidenceStep(evidence, 'cleanup', 'failed', detail);
+					progress(`cleanup FAILED: ${detail}`);
+				}
+				evidence.finishedAt = new Date().toISOString();
+				await writeRelayEvidence(`${OUTPUT_DIR}/result.json`, evidence);
+				await deploymentContext.close();
 			}
-		} else {
-			evidence.steps.cleanup = {
-				...evidence.steps.cleanup,
-				status: 'skipped',
-				detail: 'No VM was submitted.'
-			};
+
+			if (testError) throw testError;
 		}
-		evidence.finishedAt = new Date().toISOString();
-		await writeFile(`${OUTPUT_DIR}/result.json`, `${JSON.stringify(evidence, null, 2)}\n`);
-		await deploymentContext.close();
-		if (cleanupError) throw cleanupError;
-		if (testError) throw testError;
-	});
+	);
 });

--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -1,5 +1,10 @@
 const DEFAULT_TIMEOUT = 120_000;
 
+/** Timestamped live progress line so CI logs show what remote runs are doing. */
+export function remoteProgress(message) {
+	console.log(`[remote-e2e ${new Date().toISOString()}] ${message}`);
+}
+
 export class TodoBrowserAgent {
 	constructor(name, browser, appUrl, timeout = DEFAULT_TIMEOUT) {
 		this.name = name;
@@ -16,12 +21,27 @@ export class TodoBrowserAgent {
 		this.page = await this.context.newPage();
 		this.page.on('console', (message) => {
 			const text = message.text();
-			if (!/(todo|orbitdb|database peer|entry updated|connection stable|pinning)/i.test(text)) {
+			const type = message.type();
+			const relevant =
+				/(todo|orbitdb|database peer|entry updated|connect|dial|relay|tls|websocket|pinning)/i.test(
+					text
+				);
+			if (!relevant && type !== 'error' && type !== 'warning') {
 				return;
 			}
-			this.log.push(`[${message.type()}] ${text}`);
+			this.log.push(`[${type}] ${text}`);
 			if (this.log.length > 200) this.log.shift();
+			// Stream warnings/errors and relay-related lines live into the CI log:
+			// buried browser console output (e.g. TooManyOutboundProtocolStreams
+			// during relay pings) has repeatedly been the actual root cause.
+			if (type === 'error' || type === 'warning' || /relay|dial|connect/i.test(text)) {
+				remoteProgress(`[${this.name} ${type}] ${text.slice(0, 400)}`);
+			}
 		});
+		this.page.on('pageerror', (error) => {
+			remoteProgress(`[${this.name} pageerror] ${error.message}`);
+		});
+		remoteProgress(`[${this.name}] opening ${this.appUrl}...`);
 		await this.page.goto(this.appUrl, { waitUntil: 'domcontentloaded', timeout: this.timeout });
 
 		const modal = this.page.locator('div.fixed.inset-0.z-50');
@@ -30,6 +50,9 @@ export class TodoBrowserAgent {
 			for (const checkbox of await modal.locator('input[type="checkbox"]').all()) {
 				await checkbox.check();
 			}
+			// Chapter-specific: collab01 replicates a Spanish-mnemonic-named shared
+			// OrbitDB list, so open that list by its mnemonic instead of the plain
+			// "Proceed to Test the App" flow.
 			await modal.getByTestId('shared-list-mnemonic-input').fill(mnemonic);
 			await this.page.getByRole('button', { name: 'Open shared list' }).click();
 		}
@@ -67,12 +90,16 @@ export class TodoBrowserAgent {
 		return { ...diagnostics, log: this.log.slice(-100) };
 	}
 
-	async waitForReachableRelayOptions({ requirePingVerified = true } = {}) {
+	async waitForReachableRelayOptions() {
+		// #38: discovery no longer runs on page load. The dropdown is
+		// pre-populated with the build-time snapshot (data-prevalidated);
+		// live ping-verified entries (data-ping-verified) appear only after a
+		// manual refresh. Both are dialable, so accept either.
+		const optionSelector =
+			'[data-testid="reachable-relay-select"] option[data-ping-verified="true"], ' +
+			'[data-testid="reachable-relay-select"] option[data-prevalidated="true"]';
 		const select = this.page.getByTestId('reachable-relay-select');
 		await select.waitFor({ state: 'attached', timeout: this.timeout });
-		const optionSelector = requirePingVerified
-			? '[data-testid="reachable-relay-select"] option[data-ping-verified="true"]'
-			: '[data-testid="reachable-relay-select"] option[value^="/"]';
 		await this.page.waitForFunction(
 			(selector) => document.querySelectorAll(selector).length > 0,
 			optionSelector,
@@ -80,7 +107,7 @@ export class TodoBrowserAgent {
 		);
 
 		return select
-			.locator(optionSelector.replace('[data-testid="reachable-relay-select"] ', ''))
+			.locator('option[data-ping-verified="true"], option[data-prevalidated="true"]')
 			.evaluateAll((options) =>
 				options.map((option) => ({
 					address: option.value,
@@ -102,10 +129,6 @@ export class TodoBrowserAgent {
 		return this.diagnostics();
 	}
 
-	async waitForPublicDialAddress() {
-		return this.waitForDialAddress({ requirePublic: true });
-	}
-
 	async waitForDialAddress({ requirePublic = false } = {}) {
 		await this.page.waitForFunction(
 			(publicOnly) => {
@@ -125,6 +148,10 @@ export class TodoBrowserAgent {
 		);
 
 		return this.diagnostics();
+	}
+
+	async waitForPublicDialAddress() {
+		return this.waitForDialAddress({ requirePublic: true });
 	}
 
 	async connectToMultiaddr(address) {
@@ -153,45 +180,43 @@ export class TodoBrowserAgent {
 		return this.diagnostics();
 	}
 
-	async waitForDatabaseSyncPeer() {
+	async waitForDatabaseSyncPeer(timeout = this.timeout) {
 		await this.page.waitForFunction(
 			() => (window.__simpleTodoDiagnostics?.getDatabasePeers?.() ?? []).length > 0,
 			undefined,
-			{ timeout: this.timeout, polling: 500 }
+			{ timeout, polling: 1_000 }
 		);
-
 		return this.diagnostics();
 	}
 
-	async createTodo(text) {
-		await this.todoInput().fill(text);
-		await this.page.getByRole('button', { name: 'Add TODO' }).click();
-		await this.waitForTodo(text);
+	async createTodo(text, { attempts = 3, attemptTimeout = 40_000 } = {}) {
+		let lastError;
+		for (let attempt = 1; attempt <= attempts; attempt += 1) {
+			await this.todoInput().waitFor({ state: 'visible', timeout: attemptTimeout });
+			await this.todoInput().fill(text);
+			await this.page.getByRole('button', { name: 'Add TODO' }).click();
+			try {
+				await this.waitForTodo(text, attemptTimeout);
+				return;
+			} catch (error) {
+				lastError = error;
+				this.log.push(
+					`[warning] TODO creation attempt ${attempt}/${attempts} did not become visible within ${attemptTimeout}ms`
+				);
+			}
+		}
+
+		throw new Error(
+			`${this.name} could not create local TODO "${text}" after ${attempts} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`
+		);
 	}
 
-	async waitForTodo(text) {
-		await this.page
-			.getByText(text, { exact: true })
-			.waitFor({ state: 'visible', timeout: this.timeout });
+	async waitForTodo(text, timeout = this.timeout) {
+		await this.page.getByText(text, { exact: true }).waitFor({ state: 'visible', timeout });
 	}
 
 	async screenshot(path) {
 		await this.page?.screenshot({ path, fullPage: true });
-	}
-
-	async setTestingBotStatus(passed, reason) {
-		if (!this.page) return;
-		const command = JSON.stringify({
-			action: 'setSessionStatus',
-			arguments: { passed, reason }
-		});
-		await this.page.evaluate(() => {}, `testingbot_executor: ${command}`);
-	}
-
-	async getTestingBotSessionDetails() {
-		if (!this.page) return null;
-		const command = JSON.stringify({ action: 'getSessionDetails' });
-		return this.page.evaluate(() => {}, `testingbot_executor: ${command}`);
 	}
 
 	todoInput() {

--- a/e2e/remote/aleph-guest-proxy.mjs
+++ b/e2e/remote/aleph-guest-proxy.mjs
@@ -1,0 +1,45 @@
+import { readFile } from 'node:fs/promises';
+import { timingSafeEqual } from 'node:crypto';
+import { createRequire } from 'node:module';
+import http from 'node:http';
+import httpProxy from 'http-proxy';
+
+const require = createRequire(import.meta.url);
+const { version: playwrightVersion } = require('playwright/package.json');
+
+const secret = (await readFile('/etc/aleph-playwright-runner.secret', 'utf8')).trim();
+const proxy = httpProxy.createProxyServer({ target: 'ws://127.0.0.1:3000', ws: true });
+
+function authorized(request) {
+	const supplied = request.headers.authorization ?? '';
+	const expected = `Bearer ${secret}`;
+	return (
+		supplied.length === expected.length &&
+		timingSafeEqual(Buffer.from(supplied), Buffer.from(expected))
+	);
+}
+
+const server = http.createServer((request, response) => {
+	if (!authorized(request)) {
+		response.writeHead(401, { 'content-type': 'application/json' });
+		response.end('{"error":"unauthorized"}\n');
+		return;
+	}
+	if (request.url === '/version' || request.url === '/health') {
+		response.writeHead(200, { 'content-type': 'application/json', 'cache-control': 'no-store' });
+		response.end(`${JSON.stringify({ ok: true, playwrightVersion })}\n`);
+		return;
+	}
+	response.writeHead(404).end();
+});
+
+server.on('upgrade', (request, socket, head) => {
+	if (!authorized(request)) {
+		socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+		socket.destroy();
+		return;
+	}
+	proxy.ws(request, socket, head);
+});
+
+server.listen(3100, '127.0.0.1');

--- a/e2e/remote/aleph-provider-contract.mjs
+++ b/e2e/remote/aleph-provider-contract.mjs
@@ -1,0 +1,57 @@
+export const PLAYWRIGHT_VERSION = '1.61.1';
+
+/**
+ * @template T
+ * @param {(wsEndpoint: string, options: {headers: Record<string, string>, timeout: number}) => Promise<T>} connectImpl
+ * @param {string} wsEndpoint
+ * @param {Record<string, string>} headers
+ * @returns {Promise<T>}
+ */
+export function connectWithPlaywrightHeaders(connectImpl, wsEndpoint, headers) {
+	return connectImpl(wsEndpoint, { headers, timeout: 120_000 });
+}
+export const ALEPH_API_HOSTS = ['https://api2.aleph.im', 'https://api.aleph.im'];
+
+/**
+ * Caller configuration is deliberately ignored after parsing: Phase A has one
+ * trusted order and must never inherit api3 or arbitrary API origins.
+ * @param {string} value
+ */
+export function sanitizeAlephApiHosts(value = '') {
+	const safeCallerHosts = String(value)
+		.split(/[\s,]+/u)
+		.map((host) => host.trim().replace(/\/+$/u, ''))
+		.filter((host) => ALEPH_API_HOSTS.includes(host));
+	return [...new Set([...ALEPH_API_HOSTS, ...safeCallerHosts])];
+}
+
+/** @param {unknown} serverVersion @param {string} clientVersion */
+export function assertPlaywrightVersion(serverVersion, clientVersion = PLAYWRIGHT_VERSION) {
+	if (serverVersion !== clientVersion) {
+		throw new Error(
+			`Playwright client/server version mismatch: GitHub client is ${clientVersion}, Aleph VM server is ${serverVersion || 'unknown'}. Both must be exactly ${PLAYWRIGHT_VERSION}.`
+		);
+	}
+}
+
+/**
+ * @param {{versionUrl?: string, secret?: string, fetchImpl?: typeof globalThis.fetch}} options
+ */
+export async function verifyAlephPlaywrightEndpoint({
+	versionUrl,
+	secret,
+	fetchImpl = globalThis.fetch
+}) {
+	if (!versionUrl?.startsWith('https://')) {
+		throw new Error('ALEPH_PLAYWRIGHT_VERSION_URL must be an https:// endpoint.');
+	}
+	if (!secret) throw new Error('ALEPH_PLAYWRIGHT_SECRET is required for the Aleph provider.');
+	const headers = { authorization: `Bearer ${secret}` };
+	const response = await fetchImpl(versionUrl, { headers, signal: AbortSignal.timeout(30_000) });
+	if (!response.ok) {
+		throw new Error(`Aleph Playwright version preflight failed with HTTP ${response.status}.`);
+	}
+	const payload = await response.json();
+	assertPlaywrightVersion(payload.playwrightVersion);
+	return headers;
+}

--- a/e2e/remote/main-scenario.mjs
+++ b/e2e/remote/main-scenario.mjs
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from 'node:fs/promises';
-import { TodoBrowserAgent } from './agent.mjs';
+import { TodoBrowserAgent, remoteProgress } from './agent.mjs';
 import { generateSpanishMnemonic } from '../../src/lib/spanish-mnemonic.js';
 
 function hasPublicRelayConnection(diagnostics) {
@@ -37,14 +37,17 @@ export async function runMainRemoteScenario({
 	browserB,
 	appUrl,
 	outputDir,
-	remoteProvider = 'local'
+	remoteProvider = 'local',
+	remoteEvidence = {}
 }) {
 	const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 	const todoFromA = `remote-${runId}-from-a`;
 	const todoFromB = `remote-${runId}-from-b`;
+	// Chapter-specific: both browsers open the same Spanish-mnemonic-named shared
+	// OrbitDB list and replicate through it.
 	const sharedMnemonic = generateSpanishMnemonic();
 	const agentA = new TodoBrowserAgent('github-local', browserA, appUrl);
-	const agentB = new TodoBrowserAgent('testingbot-remote', browserB, appUrl);
+	const agentB = new TodoBrowserAgent(`${remoteProvider}-remote`, browserB, appUrl);
 	const result = {
 		runId,
 		appUrl,
@@ -54,35 +57,61 @@ export async function runMainRemoteScenario({
 		evidence: {},
 		passed: false
 	};
+	result.evidence.remoteProvider = { name: remoteProvider, ...remoteEvidence };
+	const requirePublicRelay = process.env.REQUIRE_PUBLIC_RELAY === 'true';
+	const setStage = (stage, detail = '') => {
+		result.evidence.stage = stage;
+		remoteProgress(`stage: ${stage}${detail ? ` (${detail})` : ''}`);
+	};
+	setStage(
+		'opening-browsers',
+		`provider=${remoteProvider}, requirePublicRelay=${requirePublicRelay}`
+	);
 
 	await mkdir(outputDir, { recursive: true });
 
 	try {
 		await Promise.all([agentA.open(sharedMnemonic), agentB.open(sharedMnemonic)]);
-		const requirePingVerified = process.env.REQUIRE_PUBLIC_RELAY === 'true';
-		const [relayOptionsA, relayOptionsB] = await Promise.all([
-			agentA.waitForReachableRelayOptions({ requirePingVerified }),
-			agentB.waitForReachableRelayOptions({ requirePingVerified })
-		]);
-		result.evidence.pingVerifiedRelayOptions = {
-			agentA: relayOptionsA,
-			agentB: relayOptionsB
-		};
-		if (process.env.REQUIRE_PUBLIC_RELAY === 'true') {
+		setStage('verifying-relays');
+		if (requirePublicRelay) {
+			const [relayOptionsA, relayOptionsB] = await Promise.all([
+				agentA.waitForReachableRelayOptions(),
+				agentB.waitForReachableRelayOptions()
+			]);
+			result.evidence.pingVerifiedRelayOptions = {
+				agentA: relayOptionsA,
+				agentB: relayOptionsB
+			};
+			remoteProgress(
+				`relay options: agentA=[${relayOptionsA.map(({ label }) => label).join(', ')}] agentB=[${relayOptionsB.map(({ label }) => label).join(', ')}]`
+			);
+			remoteProgress('waiting for a public relay connection on both browsers...');
 			await Promise.all([
 				agentA.waitForPublicRelayConnection(),
 				agentB.waitForPublicRelayConnection()
 			]);
-			await Promise.all([agentA.waitForPublicDialAddress(), agentB.waitForPublicDialAddress()]);
-		} else {
-			await Promise.all([agentA.waitForDialAddress(), agentB.waitForDialAddress()]);
 		}
+		remoteProgress('waiting for dialable peer addresses on both browsers...');
+		await Promise.all([
+			agentA.waitForDialAddress({ requirePublic: requirePublicRelay }),
+			agentB.waitForDialAddress({ requirePublic: requirePublicRelay })
+		]);
 		result.agents.a = await agentA.diagnostics();
 		result.agents.b = await agentB.diagnostics();
+		remoteProgress(
+			`peers: agentA=${result.agents.a.peerId} (${result.agents.a.connections.length} connections), agentB=${result.agents.b.peerId} (${result.agents.b.connections.length} connections)`
+		);
+		setStage('validating-shared-database');
 
 		if (
 			result.agents.a.databaseName !== sharedMnemonic ||
-			result.agents.b.databaseName !== sharedMnemonic ||
+			result.agents.b.databaseName !== sharedMnemonic
+		) {
+			throw new Error(
+				`agents did not open the shared mnemonic list "${sharedMnemonic}": agentA=${result.agents.a.databaseName}, agentB=${result.agents.b.databaseName}`
+			);
+		}
+		if (
 			!result.agents.a.databaseAddress ||
 			result.agents.a.databaseAddress !== result.agents.b.databaseAddress
 		) {
@@ -91,7 +120,7 @@ export async function runMainRemoteScenario({
 			);
 		}
 
-		if (process.env.REQUIRE_PUBLIC_RELAY === 'true') {
+		if (requirePublicRelay) {
 			if (
 				!hasPublicRelayConnection(result.agents.a) ||
 				!hasPublicRelayConnection(result.agents.b)
@@ -100,37 +129,56 @@ export async function runMainRemoteScenario({
 			}
 		}
 
+		// A direct browser-to-browser WebRTC connection is welcome but NOT
+		// required: OrbitDB sync runs over gossipsub on the relay circuit
+		// (`runOnLimitedConnection: true`), so the todo replicates relay-mediated
+		// even when the (slower/absent) direct dial never completes — proven by
+		// the UC cross-host run (<0.3 s over a single relay). Attempt the direct
+		// connection best-effort, then gate on the real signals: a database sync
+		// peer and the todo actually replicating.
+		setStage('connecting-browser-peers');
 		const addressForB = selectPeerDialAddress(result.agents.b, result.agents.b.peerId, {
-			requirePublic: process.env.REQUIRE_PUBLIC_RELAY === 'true'
+			requirePublic: requirePublicRelay
 		});
-		if (!addressForB) {
-			throw new Error(
-				`Agent B did not advertise a usable dial address for ${result.agents.b.peerId}.`
+		if (addressForB) {
+			remoteProgress(`agent A dialing agent B via ${addressForB} (best-effort)`);
+			await agentA
+				.connectToMultiaddr(addressForB)
+				.catch((error) =>
+					remoteProgress(
+						`direct dial did not complete, continuing relay-mediated: ${error instanceof Error ? error.message : String(error)}`
+					)
+				);
+			await Promise.allSettled([
+				agentA.waitForPeerConnection(result.agents.b.peerId, 30_000),
+				agentB.waitForPeerConnection(result.agents.a.peerId, 30_000)
+			]);
+		} else {
+			remoteProgress(
+				`agent B advertised no direct dial address for ${result.agents.b.peerId}; relying on relay-mediated replication`
 			);
 		}
-		await agentA.connectToMultiaddr(addressForB);
-		await Promise.all([
-			agentA.waitForPeerConnection(result.agents.b.peerId),
-			agentB.waitForPeerConnection(result.agents.a.peerId)
-		]);
 		await Promise.all([agentA.waitForDatabaseSyncPeer(), agentB.waitForDatabaseSyncPeer()]);
 		result.agents.a = await agentA.diagnostics();
 		result.agents.b = await agentB.diagnostics();
 
+		setStage('creating-todo-on-agent-a');
 		const aToBStarted = Date.now();
 		await agentA.createTodo(todoFromA);
+		setStage('replicating-agent-a-to-agent-b');
 		await agentB.waitForTodo(todoFromA);
 		result.replication.aToBMs = Date.now() - aToBStarted;
+		remoteProgress(`replicated A -> B in ${result.replication.aToBMs} ms`);
 
 		const bToAStarted = Date.now();
+		setStage('creating-todo-on-agent-b');
 		await agentB.createTodo(todoFromB);
+		setStage('replicating-agent-b-to-agent-a');
 		await agentA.waitForTodo(todoFromB);
 		result.replication.bToAMs = Date.now() - bToAStarted;
+		remoteProgress(`replicated B -> A in ${result.replication.bToAMs} ms`);
 		result.passed = true;
-		if (remoteProvider === 'testingbot') {
-			await agentB.setTestingBotStatus(true, 'Bidirectional OrbitDB replication passed.');
-			result.evidence.testingBot = await agentB.getTestingBotSessionDetails();
-		}
+		setStage('completed');
 		await Promise.all([
 			agentA.screenshot(`${outputDir}/agent-a-success.png`),
 			agentB.screenshot(`${outputDir}/agent-b-success.png`)
@@ -145,9 +193,7 @@ export async function runMainRemoteScenario({
 		if (diagnosticsA.status === 'fulfilled') result.agents.a = diagnosticsA.value;
 		if (diagnosticsB.status === 'fulfilled') result.agents.b = diagnosticsB.value;
 		result.error = error instanceof Error ? error.message : String(error);
-		if (remoteProvider === 'testingbot') {
-			await agentB.setTestingBotStatus(false, result.error).catch(() => {});
-		}
+		remoteProgress(`FAILED at stage "${result.evidence.stage}": ${result.error}`);
 		await Promise.allSettled([
 			agentA.screenshot(`${outputDir}/agent-a-failure.png`),
 			agentB.screenshot(`${outputDir}/agent-b-failure.png`)

--- a/e2e/remote/providers.mjs
+++ b/e2e/remote/providers.mjs
@@ -1,9 +1,28 @@
 import { chromium } from 'playwright';
+import { createRequire } from 'node:module';
+export {
+	ALEPH_API_HOSTS,
+	assertPlaywrightVersion,
+	connectWithPlaywrightHeaders,
+	PLAYWRIGHT_VERSION,
+	sanitizeAlephApiHosts,
+	verifyAlephPlaywrightEndpoint
+} from './aleph-provider-contract.mjs';
+import {
+	assertPlaywrightVersion,
+	connectWithPlaywrightHeaders,
+	PLAYWRIGHT_VERSION,
+	verifyAlephPlaywrightEndpoint
+} from './aleph-provider-contract.mjs';
+
+const require = createRequire(import.meta.url);
+const installedPlaywrightVersion = require('playwright/package.json').version;
 
 export async function createLocalBrowser() {
 	return chromium.launch({ headless: true });
 }
 
+/** @param {{key?: string, secret?: string, buildName: string, testName: string}} options */
 export async function createTestingBotBrowser({ key, secret, buildName, testName }) {
 	if (!key || !secret) {
 		throw new Error(
@@ -29,4 +48,29 @@ export async function createTestingBotBrowser({ key, secret, buildName, testName
 		)}`,
 		timeout: 120_000
 	});
+}
+
+/**
+ * @param {{
+ *  wsEndpoint?: string,
+ *  secret?: string,
+ *  versionUrl?: string,
+ *  fetchImpl?: typeof globalThis.fetch,
+ *  connectImpl?: (wsEndpoint: string, options: any) => Promise<any>
+ * }} options
+ */
+export async function createAlephBrowser({
+	wsEndpoint,
+	secret,
+	versionUrl,
+	fetchImpl = globalThis.fetch,
+	connectImpl = (endpoint, options) => chromium.connect(endpoint, options)
+}) {
+	assertPlaywrightVersion(installedPlaywrightVersion, PLAYWRIGHT_VERSION);
+	if (!wsEndpoint?.startsWith('wss://')) {
+		throw new Error('ALEPH_PLAYWRIGHT_WS_ENDPOINT must be an authenticated wss:// endpoint.');
+	}
+	const headers = await verifyAlephPlaywrightEndpoint({ versionUrl, secret, fetchImpl });
+
+	return connectWithPlaywrightHeaders(connectImpl, wsEndpoint, headers);
 }

--- a/e2e/remote/run-main.mjs
+++ b/e2e/remote/run-main.mjs
@@ -1,25 +1,55 @@
 import { writeFile } from 'node:fs/promises';
-import { createHash } from 'node:crypto';
-import { createLocalBrowser, createTestingBotBrowser } from './providers.mjs';
+import {
+	createAlephBrowser,
+	createLocalBrowser,
+	createTestingBotBrowser,
+	PLAYWRIGHT_VERSION
+} from './providers.mjs';
 import { runMainRemoteScenario } from './main-scenario.mjs';
 
 const appUrl = process.env.REMOTE_APP_URL || 'https://simple-todo.le-space.de';
-const provider = process.env.REMOTE_PROVIDER || 'local';
+const provider = process.env.REMOTE_PROVIDER || 'aleph';
 const outputDir = process.env.REMOTE_OUTPUT_DIR || 'test-results/remote-main';
 const buildName = process.env.GITHUB_RUN_ID
 	? `simple-todo-${process.env.GITHUB_RUN_ID}`
 	: `simple-todo-${Date.now()}`;
 
 const browserA = await createLocalBrowser();
-const browserB =
-	provider === 'testingbot'
-		? await createTestingBotBrowser({
-				key: process.env.TESTINGBOT_KEY,
-				secret: process.env.TESTINGBOT_SECRET,
-				buildName,
-				testName: 'main cross-network OrbitDB replication'
-			})
-		: await createLocalBrowser();
+let browserB;
+try {
+	if (provider === 'testingbot') {
+		browserB = await createTestingBotBrowser({
+			key: process.env.TESTINGBOT_KEY,
+			secret: process.env.TESTINGBOT_SECRET,
+			buildName,
+			testName: 'main cross-network OrbitDB replication'
+		});
+	} else if (provider === 'aleph') {
+		browserB = await createAlephBrowser({
+			wsEndpoint: process.env.ALEPH_PLAYWRIGHT_WS_ENDPOINT,
+			versionUrl: process.env.ALEPH_PLAYWRIGHT_VERSION_URL,
+			secret: process.env.ALEPH_PLAYWRIGHT_SECRET
+		});
+	} else if (provider === 'local') {
+		browserB = await createLocalBrowser();
+	} else {
+		throw new Error(`Unsupported REMOTE_PROVIDER "${provider}". Use aleph, local, or testingbot.`);
+	}
+} catch (error) {
+	await browserA.close();
+	throw error;
+}
+
+const remoteEvidence =
+	provider === 'aleph'
+		? {
+				instanceHash: process.env.ALEPH_PLAYWRIGHT_INSTANCE_HASH ?? null,
+				crnHash: process.env.ALEPH_PLAYWRIGHT_CRN_HASH ?? null,
+				crnName: process.env.ALEPH_PLAYWRIGHT_CRN_NAME ?? null,
+				region: process.env.ALEPH_PLAYWRIGHT_REGION ?? null,
+				playwrightVersion: PLAYWRIGHT_VERSION
+			}
+		: {};
 
 try {
 	const result = await runMainRemoteScenario({
@@ -27,24 +57,15 @@ try {
 		browserB,
 		appUrl,
 		outputDir,
-		remoteProvider: provider
+		remoteProvider: provider,
+		remoteEvidence
 	});
 	const githubRunUrl = process.env.GITHUB_RUN_ID
 		? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
 		: null;
 	const githubArtifactsUrl = githubRunUrl ? `${githubRunUrl}#artifacts` : null;
-	const testingBotSessionId = result.evidence.testingBot?.sessionId ?? null;
-	const testingBotShareUrl =
-		testingBotSessionId && process.env.TESTINGBOT_KEY && process.env.TESTINGBOT_SECRET
-			? `https://testingbot.com/tests/${testingBotSessionId}?auth=${createHash('md5')
-					.update(
-						`${process.env.TESTINGBOT_KEY}:${process.env.TESTINGBOT_SECRET}:${testingBotSessionId}`
-					)
-					.digest('hex')}`
-			: null;
 	result.evidence.githubRunUrl = githubRunUrl;
 	result.evidence.githubArtifactsUrl = githubArtifactsUrl;
-	result.evidence.testingBotShareUrl = testingBotShareUrl;
 	console.log(JSON.stringify(result, null, 2));
 	if (process.env.GITHUB_STEP_SUMMARY) {
 		await writeFile(
@@ -63,7 +84,9 @@ try {
 				(githubArtifactsUrl
 					? `- [Success screenshots and result JSON](${githubArtifactsUrl})\n`
 					: '') +
-				(testingBotShareUrl ? `- [TestingBot session and video](${testingBotShareUrl})\n` : ''),
+				(provider === 'aleph'
+					? `- Aleph INSTANCE: \`${remoteEvidence.instanceHash ?? 'unknown'}\`\n- CRN/region: \`${remoteEvidence.crnName ?? remoteEvidence.crnHash ?? 'unknown'}\` / \`${remoteEvidence.region ?? 'unknown'}\`\n- Playwright: \`${PLAYWRIGHT_VERSION}\`\n`
+					: ''),
 			{ flag: 'a' }
 		);
 	}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",
 		"@eslint/js": "^9.18.0",
-		"@playwright/test": "^1.61.1",
+		"@le-space/playwright": "0.6.35",
+		"@playwright/test": "1.61.1",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
@@ -40,7 +41,7 @@
 		"globals": "^16.0.0",
 		"node-fetch": "^3.3.2",
 		"orbitdb-relay": "^0.9.7",
-		"playwright": "^1.61.1",
+		"playwright": "1.61.1",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,11 @@ importers:
       '@eslint/js':
         specifier: ^9.18.0
         version: 9.32.0
+      '@le-space/playwright':
+        specifier: 0.6.35
+        version: 0.6.35(@playwright/test@1.61.1)(typescript@5.9.2)
       '@playwright/test':
-        specifier: ^1.61.1
+        specifier: 1.61.1
         version: 1.61.1
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
@@ -170,7 +173,7 @@ importers:
         specifier: ^0.9.7
         version: 0.9.7(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
       playwright:
-        specifier: ^1.61.1
+        specifier: 1.61.1
         version: 1.61.1
       prettier:
         specifier: ^3.4.2
@@ -882,11 +885,17 @@ packages:
   '@le-space/aleph-bootstrap@0.6.26':
     resolution: {integrity: sha512-vFz8A0Ql8ylhHG7db9HRkByBYtHKzV7R0CXVX2ST/KqBjeAGMPKsVZoJfRdfZQ9AnmGGNgY5L54n6D2VoQ2cVA==}
 
+  '@le-space/aleph-bootstrap@0.6.35':
+    resolution: {integrity: sha512-jCEmQRHOM2P46r/ISfQGQ/YRNUNMlVo27VtdKVl5vutSFdsoXLEEB/h7ilVwBAEsz9zZH51Uy9x660xjYk0cog==}
+
   '@le-space/browser@0.6.26':
     resolution: {integrity: sha512-p/2mkXQJJImpa9Bc5vE2BSIyIB4N/klyx2ORH2pWTpa720WabeSYERd1PJum67nptlpn1vFecYizDAihonTVSQ==}
 
   '@le-space/core@0.6.26':
     resolution: {integrity: sha512-hCXu8AcU1CjodMd1iHpf6B5c/NaWupFIE6Ym+/NV5Aav3OK/l8zKimFeYCG2JPGHSwk04ksW3Pv3hqg2+0q5tQ==}
+
+  '@le-space/core@0.6.35':
+    resolution: {integrity: sha512-8jjGKyiByJ9U7NpCv825J63k7VbF5okAU0JS0cOLziCdcPMPtpF3E9ZV4f67jGr4w4BcdOPGBAIX4nb+3XueEw==}
 
   '@le-space/iso-base@4.3.0':
     resolution: {integrity: sha512-aZerTomLgkGAAh6zAa8PWQu2rfMzrA5tiBIe4PWI8LDBJHwlgFwRsiDpdM/3eRjE7ocHi4rrPXdVfy+FH7knFA==}
@@ -912,8 +921,17 @@ packages:
     peerDependencies:
       '@orbitdb/core': ^4.0.0
 
+  '@le-space/playwright@0.6.35':
+    resolution: {integrity: sha512-TqC6/yEMCVLxU+FaMaBG1voQQKz5zbafenJ1pnlR/AcpOo7ZuwfHuy7IQ+XdVLMENd0EoWSo2kL+pRlxcvsICQ==}
+    hasBin: true
+    peerDependencies:
+      '@playwright/test': '>=1.61.1 <1.62.0'
+
   '@le-space/shared-types@0.6.26':
     resolution: {integrity: sha512-Kw+avCoxyOKKFhqUn7GJChvW0XNxqCgcBwXZeBuGqA+R9ixC0SN12FxqSE0akC1lsZ0XTYNvNTsC3xYbz4OxdQ==}
+
+  '@le-space/shared-types@0.6.35':
+    resolution: {integrity: sha512-xIdEQ6WHb063uj9ixagno1GdxCvHjNXgScJttZS1kZN2z0X+50kRIitWzL3RQpQIRXMLyHiuharw/j5jZCZeZg==}
 
   '@le-space/ucanto-interface@11.1.1':
     resolution: {integrity: sha512-K7f/itvJMeeYyylR9D1TD83IBBW9OWrhdjEGT6vFcsjaResVL1zFVte3kt+8opyGhqgSNJ8cLotEfIbDcKyrkw==}
@@ -5901,12 +5919,32 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@le-space/aleph-bootstrap@0.6.35(typescript@5.9.2)':
+    dependencies:
+      '@libp2p/bootstrap': 11.0.47
+      viem: 2.53.1(typescript@5.9.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@le-space/browser@0.6.26': {}
 
   '@le-space/core@0.6.26(typescript@5.9.2)':
     dependencies:
       '@le-space/aleph-bootstrap': 0.6.26(typescript@5.9.2)
       '@le-space/shared-types': 0.6.26
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@le-space/core@0.6.35(typescript@5.9.2)':
+    dependencies:
+      '@le-space/aleph-bootstrap': 0.6.35(typescript@5.9.2)
+      '@le-space/shared-types': 0.6.35
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -5964,7 +6002,20 @@ snapshots:
       - rollup
       - vite
 
+  '@le-space/playwright@0.6.35(@playwright/test@1.61.1)(typescript@5.9.2)':
+    dependencies:
+      '@le-space/aleph-bootstrap': 0.6.35(typescript@5.9.2)
+      '@le-space/core': 0.6.35(typescript@5.9.2)
+      '@playwright/test': 1.61.1
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@le-space/shared-types@0.6.26': {}
+
+  '@le-space/shared-types@0.6.35': {}
 
   '@le-space/ucanto-interface@11.1.1':
     dependencies:

--- a/scripts/check-aleph-playwright-preflight.mjs
+++ b/scripts/check-aleph-playwright-preflight.mjs
@@ -1,0 +1,32 @@
+import { privateKeyToAccount } from 'viem/accounts';
+import { sanitizeAlephApiHosts } from '../e2e/remote/aleph-provider-contract.mjs';
+
+const rawKey = process.env.ALEPH_VM_PRIVATE_KEY?.trim();
+if (!rawKey) throw new Error('ALEPH_VM_PRIVATE_KEY is required for the Aleph provider.');
+const account = privateKeyToAccount(rawKey.startsWith('0x') ? rawKey : `0x${rawKey}`);
+const hosts = sanitizeAlephApiHosts(process.env.ALEPH_VM_API_HOSTS);
+const minimumCredits = Number(process.env.ALEPH_PLAYWRIGHT_MINIMUM_CREDITS ?? 20_000);
+let lastError;
+
+for (const host of hosts) {
+	try {
+		const response = await fetch(`${host}/api/v0/addresses/${account.address}/balance`, {
+			signal: AbortSignal.timeout(15_000)
+		});
+		if (!response.ok) throw new Error(`HTTP ${response.status}`);
+		const balance = await response.json();
+		const available = Number(balance.credit_balance ?? balance.balance ?? 0);
+		if (!Number.isFinite(available) || available < minimumCredits) {
+			throw new Error(
+				`Aleph account has ${available} credits; at least ${minimumCredits} are required.`
+			);
+		}
+		console.log(
+			`Aleph preflight passed for ${account.address} through ${host}: ${available} credits.`
+		);
+		process.exit(0);
+	} catch (error) {
+		lastError = error;
+	}
+}
+throw new Error(`Aleph credential/credit preflight failed on api2 and api: ${lastError?.message}`);

--- a/scripts/cleanup-aleph-playwright-runner.mjs
+++ b/scripts/cleanup-aleph-playwright-runner.mjs
@@ -1,0 +1,139 @@
+import { createHash } from 'node:crypto';
+import { appendFile, mkdir, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { sanitizeAlephApiHosts } from '../e2e/remote/aleph-provider-contract.mjs';
+
+const outputPath = 'test-results/remote-main/aleph-cleanup.json';
+await mkdir('test-results/remote-main', { recursive: true });
+const instanceHash = process.env.ALEPH_PLAYWRIGHT_INSTANCE_HASH?.trim();
+const result = {
+	instanceHash: instanceHash || null,
+	runtimeErase: null,
+	forget: null,
+	apiConfirmation: {},
+	schedulerDeallocated: false
+};
+
+async function finish(payload, failed = false) {
+	await writeFile(outputPath, `${JSON.stringify(payload, null, 2)}\n`);
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		await appendFile(
+			process.env.GITHUB_STEP_SUMMARY,
+			`\n## Aleph Playwright cleanup\n\n` +
+				`- Exact INSTANCE: \`${payload.instanceHash ?? 'none'}\`\n` +
+				`- Runtime erase: \`${payload.runtimeErase?.status ?? (payload.skipped ? 'skipped' : 'unknown')}\`\n` +
+				`- Owner FORGET: \`${payload.forget?.status ?? (payload.skipped ? 'skipped' : 'unknown')}\`\n` +
+				`- api2 confirmed: \`${payload.apiConfirmation?.['https://api2.aleph.im'] ?? false}\`\n` +
+				`- api confirmed: \`${payload.apiConfirmation?.['https://api.aleph.im'] ?? false}\`\n` +
+				`- Scheduler deallocated: \`${payload.schedulerDeallocated ?? false}\`\n`
+		);
+	}
+	if (failed) process.exitCode = 1;
+}
+
+if (!instanceHash) {
+	await finish({ ...result, skipped: true, reason: 'No INSTANCE hash was produced.' });
+} else {
+	if (!/^[a-f0-9]{64}$/iu.test(instanceHash))
+		throw new Error('Refusing cleanup: invalid exact INSTANCE hash.');
+	const nodeModulePath = process.env.LE_SPACE_NODE_MODULE_PATH;
+	const coreModulePath = process.env.LE_SPACE_CORE_MODULE_PATH;
+	if (!nodeModulePath || !coreModulePath) throw new Error('Cleanup module paths are required.');
+	const [{ createPrivateKeyIdentity }, { eraseInstanceOnCrn, forgetAlephMessages }] =
+		await Promise.all([
+			import(pathToFileURL(nodeModulePath)),
+			import(pathToFileURL(coreModulePath))
+		]);
+	const identity = await createPrivateKeyIdentity(process.env.ALEPH_VM_PRIVATE_KEY);
+	const hosts = sanitizeAlephApiHosts(process.env.ALEPH_VM_API_HOSTS);
+	const fetchImpl = globalThis.fetch.bind(globalThis);
+	const hasher = async (content) => createHash('sha256').update(content).digest('hex');
+
+	try {
+		result.runtimeErase = await eraseInstanceOnCrn({
+			sender: identity.address,
+			signer: identity.signer,
+			instanceHash,
+			fetch: fetchImpl,
+			apiHost: hosts[0]
+		});
+	} catch (error) {
+		result.runtimeErase = {
+			status: 'failed',
+			error: error instanceof Error ? error.message : String(error)
+		};
+	}
+
+	let forgetError;
+	for (const apiHost of hosts) {
+		try {
+			result.forget = await forgetAlephMessages({
+				sender: identity.address,
+				hashes: [instanceHash],
+				reason: `Phase A Playwright runner cleanup for ${instanceHash}`,
+				signer: identity.signer,
+				hasher,
+				fetch: fetchImpl,
+				apiHost,
+				sync: true
+			});
+			break;
+		} catch (error) {
+			forgetError = error;
+		}
+	}
+	if (!result.forget) {
+		result.forget = {
+			status: 'failed',
+			error: forgetError instanceof Error ? forgetError.message : String(forgetError)
+		};
+	}
+
+	for (const apiHost of hosts) {
+		let confirmed = false;
+		for (let attempt = 0; attempt < 18; attempt += 1) {
+			const response = await fetch(`${apiHost}/api/v0/messages/${instanceHash}`, {
+				cache: 'no-store'
+			}).catch(() => null);
+			if (response?.status === 404 || response?.status === 410) {
+				confirmed = true;
+				break;
+			}
+			const payload = response?.ok ? await response.json().catch(() => ({})) : {};
+			if (
+				payload.forgotten === true ||
+				payload.forgotten_by ||
+				String(payload.status).toLowerCase() === 'forgotten'
+			) {
+				confirmed = true;
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 5_000));
+		}
+		result.apiConfirmation[apiHost] = confirmed;
+	}
+
+	for (let attempt = 0; attempt < 18; attempt += 1) {
+		const response = await fetch(
+			`https://scheduler.api.aleph.cloud/api/v0/allocation/${instanceHash}`,
+			{ cache: 'no-store' }
+		).catch(() => null);
+		if (response?.status === 404 || response?.status === 410) {
+			result.schedulerDeallocated = true;
+			break;
+		}
+		const payload = response?.ok ? await response.json().catch(() => null) : null;
+		if (response?.ok && payload && (payload.vm_ipv6 === null || payload.node === null)) {
+			result.schedulerDeallocated = true;
+			break;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 5_000));
+	}
+
+	const failed =
+		!result.forget ||
+		result.forget.status === 'failed' ||
+		!hosts.every((host) => result.apiConfirmation[host] === true) ||
+		result.schedulerDeallocated !== true;
+	await finish(result, failed);
+}

--- a/scripts/collect-aleph-playwright-logs.sh
+++ b/scripts/collect-aleph-playwright-logs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p test-results/remote-main
+if [[ -z ${ALEPH_PLAYWRIGHT_HOST:-} || -z ${ALEPH_PLAYWRIGHT_SSH_PORT:-} || -z ${ALEPH_PLAYWRIGHT_SSH_KEY:-} ]]; then
+	echo 'Guest log collection skipped: SSH runtime details unavailable.' >test-results/remote-main/aleph-guest.log
+	exit 0
+fi
+ssh -i "$ALEPH_PLAYWRIGHT_SSH_KEY" -p "$ALEPH_PLAYWRIGHT_SSH_PORT" \
+	-o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 root@"$ALEPH_PLAYWRIGHT_HOST" \
+	'systemctl status caddy aleph-playwright-server aleph-playwright-auth-proxy --no-pager -l || true; ss -ltnp; journalctl -u caddy -u aleph-playwright-server -u aleph-playwright-auth-proxy -u aleph-playwright-runner-ttl --no-pager -n 400' \
+	>test-results/remote-main/aleph-guest.log 2>&1 || true

--- a/scripts/connect-aleph-playwright-runner.sh
+++ b/scripts/connect-aleph-playwright-runner.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${ALEPH_PLAYWRIGHT_HOST:?missing host}"
+: "${ALEPH_PLAYWRIGHT_SSH_PORT:?missing SSH port}"
+: "${ALEPH_PLAYWRIGHT_SSH_KEY:?missing SSH key}"
+: "${ALEPH_PLAYWRIGHT_SECRET:?missing per-run secret}"
+: "${ALEPH_PLAYWRIGHT_TLS_CERT:?missing per-run TLS certificate}"
+: "${ALEPH_PLAYWRIGHT_TLS_KEY:?missing per-run TLS key}"
+
+ssh_opts=(-i "$ALEPH_PLAYWRIGHT_SSH_KEY" -p "$ALEPH_PLAYWRIGHT_SSH_PORT" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20)
+scp_opts=(-i "$ALEPH_PLAYWRIGHT_SSH_KEY" -P "$ALEPH_PLAYWRIGHT_SSH_PORT" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20)
+for _ in {1..30}; do
+	if ssh "${ssh_opts[@]}" root@"$ALEPH_PLAYWRIGHT_HOST" true 2>/dev/null; then break; fi
+	sleep 5
+done
+
+printf '%s' "$ALEPH_PLAYWRIGHT_SECRET" | ssh "${ssh_opts[@]}" root@"$ALEPH_PLAYWRIGHT_HOST" \
+	'umask 077; cat >/etc/aleph-playwright-runner.secret'
+scp "${scp_opts[@]}" e2e/remote/aleph-guest-proxy.mjs \
+	root@"$ALEPH_PLAYWRIGHT_HOST":/tmp/aleph-guest-proxy.mjs
+scp "${scp_opts[@]}" scripts/setup-aleph-playwright-runner.sh \
+	root@"$ALEPH_PLAYWRIGHT_HOST":/tmp/setup-aleph-playwright-runner.sh
+scp "${scp_opts[@]}" "$ALEPH_PLAYWRIGHT_TLS_CERT" \
+	root@"$ALEPH_PLAYWRIGHT_HOST":/tmp/aleph-playwright-runner.crt
+scp "${scp_opts[@]}" "$ALEPH_PLAYWRIGHT_TLS_KEY" \
+	root@"$ALEPH_PLAYWRIGHT_HOST":/tmp/aleph-playwright-runner.key
+ssh "${ssh_opts[@]}" root@"$ALEPH_PLAYWRIGHT_HOST" 'bash /tmp/setup-aleph-playwright-runner.sh'

--- a/scripts/prepare-aleph-playwright-runtime.mjs
+++ b/scripts/prepare-aleph-playwright-runtime.mjs
@@ -1,0 +1,69 @@
+import { appendFile, mkdir, writeFile } from 'node:fs/promises';
+import { lookup } from 'node:dns/promises';
+
+const host = process.env.ALEPH_DEPLOY_HOST?.trim();
+const proxyUrl = process.env.ALEPH_DEPLOY_PROXY_URL?.trim().replace(/\/+$/u, '');
+const instanceHash = process.env.ALEPH_DEPLOY_INSTANCE_HASH?.trim();
+const mappedPorts = JSON.parse(process.env.ALEPH_DEPLOY_MAPPED_PORTS_JSON || '{}');
+const sshPort = Number(mappedPorts['22']?.host);
+const tlsPort = Number(mappedPorts['443']?.host);
+if (
+	!host ||
+	!proxyUrl ||
+	!instanceHash ||
+	!Number.isInteger(sshPort) ||
+	!Number.isInteger(tlsPort)
+) {
+	throw new Error(
+		'Aleph deployment did not return host, proxy URL, exact INSTANCE hash, and SSH/TLS mappings.'
+	);
+}
+const httpsOrigin = `https://${host}:${tlsPort}`;
+const wssEndpoint = httpsOrigin.replace(/^https:/u, 'wss:');
+let region = 'unknown';
+try {
+	const crnPayload = await fetch('https://crns-list.aleph.sh/crns.json').then((response) =>
+		response.json()
+	);
+	const selectedCrn = (crnPayload.crns ?? []).find(
+		(crn) => crn.hash === process.env.ALEPH_DEPLOY_CRN_HASH
+	);
+	const hostname = new URL(selectedCrn.address).hostname;
+	const { address } = await lookup(hostname, { family: 4 });
+	const location = await fetch(`https://api.country.is/${address}`).then((response) =>
+		response.json()
+	);
+	region = location.country ?? 'unknown';
+} catch {
+	region = process.env.ALEPH_PLAYWRIGHT_REGION ?? 'unknown';
+}
+const envLines = [
+	`ALEPH_PLAYWRIGHT_HOST=${host}`,
+	`ALEPH_PLAYWRIGHT_SSH_PORT=${sshPort}`,
+	`ALEPH_PLAYWRIGHT_TLS_PORT=${tlsPort}`,
+	`ALEPH_PLAYWRIGHT_INSTANCE_HASH=${instanceHash}`,
+	`ALEPH_PLAYWRIGHT_WS_ENDPOINT=${wssEndpoint}`,
+	`ALEPH_PLAYWRIGHT_VERSION_URL=${httpsOrigin}/version`,
+	`ALEPH_PLAYWRIGHT_REGION=${region}`
+];
+await appendFile(process.env.GITHUB_ENV, `${envLines.join('\n')}\n`);
+await mkdir('test-results/remote-main', { recursive: true });
+await writeFile(
+	'test-results/remote-main/aleph-instance.json',
+	`${JSON.stringify(
+		{
+			instanceHash,
+			crnHash: process.env.ALEPH_DEPLOY_CRN_HASH || null,
+			crnName: process.env.ALEPH_DEPLOY_CRN_NAME || null,
+			region,
+			hostIpv4: host,
+			sshPort,
+			tlsPort,
+			proxyOrigin: httpsOrigin,
+			reserved2n6Proxy: proxyUrl,
+			playwrightVersion: '1.61.1'
+		},
+		null,
+		2
+	)}\n`
+);

--- a/scripts/run-aleph-playwright-deploy.mjs
+++ b/scripts/run-aleph-playwright-deploy.mjs
@@ -1,0 +1,10 @@
+import { pathToFileURL } from 'node:url';
+import { sanitizeAlephApiHosts } from '../e2e/remote/aleph-provider-contract.mjs';
+
+const modulePath = process.env.LE_SPACE_NODE_MODULE_PATH;
+if (!modulePath) throw new Error('LE_SPACE_NODE_MODULE_PATH is required.');
+const hosts = sanitizeAlephApiHosts(process.env.ALEPH_VM_API_HOSTS);
+process.env.ALEPH_VM_API_HOST = hosts[0];
+process.env.ALEPH_VM_API_HOSTS = hosts.join(',');
+const { runActionMode } = await import(pathToFileURL(modulePath));
+await runActionMode(process.env);

--- a/scripts/setup-aleph-playwright-runner.sh
+++ b/scripts/setup-aleph-playwright-runner.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+	echo 'Guest setup must run as root.' >&2
+	exit 1
+fi
+
+test -s /etc/aleph-playwright-runner.secret
+test -s /tmp/aleph-playwright-runner.crt
+test -s /tmp/aleph-playwright-runner.key
+install -d -m 0755 /opt/aleph-playwright-runner
+install -m 0644 /tmp/aleph-guest-proxy.mjs /opt/aleph-playwright-runner/proxy.mjs
+install -m 0644 /tmp/aleph-playwright-runner.crt /etc/aleph-playwright-runner.crt
+install -o root -g caddy -m 0640 \
+	/tmp/aleph-playwright-runner.key /etc/aleph-playwright-runner.key
+
+stop_rootfs_web_services() {
+	for service in \
+		orbitdb-relay-pinner.service \
+		orbitdb-relay-setup.service \
+		nginx.service \
+		apache2.service \
+		lighttpd.service; do
+		systemctl disable --now "$service" 2>/dev/null || true
+	done
+}
+
+stop_rootfs_web_services
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq ca-certificates curl gnupg
+curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+apt-get install -y -qq nodejs
+npm install --prefix /opt/aleph-playwright-runner --omit=dev --no-audit --no-fund \
+	playwright@1.61.1 http-proxy@1.18.1
+/opt/aleph-playwright-runner/node_modules/.bin/playwright install --with-deps chromium
+
+# Phase A intentionally reuses the relay RootFS. Stop its application services,
+# but preserve Caddy as the TLS terminator. A per-run certificate avoids relying
+# on a CRN's optional 2n6-to-guest IPv6 route.
+stop_rootfs_web_services
+if ! command -v caddy >/dev/null; then
+	echo 'The Phase A RootFS does not provide the Caddy TLS terminator.' >&2
+	exit 1
+fi
+
+install -d -m 0755 /etc/caddy
+if [[ -f /etc/caddy/Caddyfile ]]; then
+	cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.pre-playwright
+fi
+cat >/etc/caddy/Caddyfile <<'CADDY'
+{
+	auto_https disable_redirects
+}
+
+https://:443 {
+	tls /etc/aleph-playwright-runner.crt /etc/aleph-playwright-runner.key
+	reverse_proxy 127.0.0.1:3100
+}
+CADDY
+caddy validate --config /etc/caddy/Caddyfile
+
+# The relay RootFS delays Caddy until relay-specific configuration exists. This
+# ephemeral runner supplies its own complete Caddyfile, so remove only that
+# inherited condition from this VM after boot.
+rm -f /etc/systemd/system/caddy.service.d/orbitdb-relay.conf
+
+cat >/etc/systemd/system/aleph-playwright-server.service <<'UNIT'
+[Unit]
+Description=Authenticated Aleph Playwright server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/aleph-playwright-runner
+ExecStart=/opt/aleph-playwright-runner/node_modules/.bin/playwright run-server --host 127.0.0.1 --port 3000
+Restart=on-failure
+RestartSec=2
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+cat >/etc/systemd/system/aleph-playwright-auth-proxy.service <<'UNIT'
+[Unit]
+Description=Authenticated HTTP/WebSocket proxy for Playwright
+After=aleph-playwright-server.service
+Requires=aleph-playwright-server.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/aleph-playwright-runner
+ExecStart=/usr/bin/node /opt/aleph-playwright-runner/proxy.mjs
+Restart=on-failure
+RestartSec=2
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+cat >/etc/systemd/system/aleph-playwright-runner-ttl.service <<'UNIT'
+[Unit]
+Description=Stop an orphaned Phase A Playwright VM
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl poweroff
+UNIT
+
+cat >/etc/systemd/system/aleph-playwright-runner-ttl.timer <<'UNIT'
+[Unit]
+Description=Maximum 45 minute lifetime for Phase A Playwright VM
+
+[Timer]
+OnActiveSec=45min
+AccuracySec=30s
+Unit=aleph-playwright-runner-ttl.service
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now aleph-playwright-server.service aleph-playwright-auth-proxy.service
+systemctl enable caddy.service
+systemctl restart caddy.service
+systemctl enable --now aleph-playwright-runner-ttl.timer
+
+for _ in {1..60}; do
+	if systemctl is-active --quiet caddy.service && \
+		curl -kfsS -H "Authorization: Bearer $(cat /etc/aleph-playwright-runner.secret)" \
+			https://127.0.0.1/version | grep -q '"playwrightVersion":"1.61.1"'; then
+		exit 0
+	fi
+	sleep 2
+done
+
+systemctl status caddy.service --no-pager -l >&2 || true
+ss -ltnp >&2 || true
+journalctl -u aleph-playwright-server -u aleph-playwright-auth-proxy -u caddy --no-pager -n 150 >&2
+exit 1

--- a/scripts/write-relay-e2e-summary.mjs
+++ b/scripts/write-relay-e2e-summary.mjs
@@ -1,74 +1,24 @@
+import { appendRelayGithubSummary } from '@le-space/playwright';
 import { appendFile, readFile } from 'node:fs/promises';
+
+// Render the relay-button E2E evidence (written by the shared test kit's
+// writeRelayEvidence) into the GitHub job summary using the kit's own
+// formatter, so both consumers report the run identically (issue #29).
 
 const resultPath = process.argv[2] ?? 'test-results/relay-button/result.json';
 const summaryPath = process.env.GITHUB_STEP_SUMMARY;
-
-if (!summaryPath) process.exit(0);
-
-function workflowCommandValue(value) {
-	return String(value).replaceAll('%', '%25').replaceAll('\r', '%0D').replaceAll('\n', '%0A');
-}
 
 let result;
 try {
 	result = JSON.parse(await readFile(resultPath, 'utf8'));
 } catch (error) {
-	console.log(
-		`::error title=Relay button E2E::${workflowCommandValue(`No structured test result was produced: ${error instanceof Error ? error.message : String(error)}`)}`
-	);
-	await appendFile(
-		summaryPath,
-		`## Relay button E2E\n\n❌ No structured test result was produced.\n\n\`${error instanceof Error ? error.message : String(error)}\`\n`
-	);
+	if (summaryPath) {
+		await appendFile(
+			summaryPath,
+			`## Relay button E2E\n\n❌ No structured test result was produced.\n\n\`${error instanceof Error ? error.message : String(error)}\`\n`
+		);
+	}
 	process.exit(0);
 }
 
-const icon = {
-	passed: '✅',
-	failed: '❌',
-	pending: '⏳',
-	skipped: '⏭️'
-};
-const rows = Object.values(result.steps ?? {}).map(
-	(step) =>
-		`| ${icon[step.status] ?? '•'} | ${step.label} | ${step.status} | ${String(step.detail ?? '').replaceAll('|', '\\|')} |`
-);
-const passed = Object.values(result.steps ?? {}).every((step) =>
-	['passed', 'skipped'].includes(step.status)
-);
-const duration =
-	result.startedAt && result.finishedAt
-		? `${Math.round((Date.parse(result.finishedAt) - Date.parse(result.startedAt)) / 1000)} s`
-		: 'unknown';
-const details = [
-	`- Result: **${passed ? 'passed' : 'failed or incomplete'}**`,
-	`- Instance: \`${result.instanceName ?? 'unknown'}\``,
-	`- Relay peer: \`${result.registration?.content?.peerId ?? 'not available'}\``,
-	`- Relay address: \`${result.relayAddress ?? 'not available'}\``,
-	`- Duration: ${duration}`
-];
-if (result.error) details.push(`- Error: \`${String(result.error).replaceAll('`', "'")}\``);
-
-if (!passed) {
-	const failedSteps = Object.values(result.steps ?? {})
-		.filter((step) => !['passed', 'skipped'].includes(step.status))
-		.map((step) => `${step.label}: ${step.status}${step.detail ? ` (${step.detail})` : ''}`)
-		.join('; ');
-	console.log(
-		`::error title=Relay button E2E::${workflowCommandValue(result.error ?? failedSteps ?? 'Relay provisioning failed')}`
-	);
-}
-
-await appendFile(
-	summaryPath,
-	[
-		'## Relay button E2E',
-		'',
-		...details,
-		'',
-		'| | Test step | Status | Evidence |',
-		'|---|---|---|---|',
-		...rows,
-		''
-	].join('\n')
-);
+await appendRelayGithubSummary(result, { title: 'Relay button E2E' });

--- a/src/lib/aleph-playwright-provider.spec.js
+++ b/src/lib/aleph-playwright-provider.spec.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+	ALEPH_API_HOSTS,
+	assertPlaywrightVersion,
+	connectWithPlaywrightHeaders,
+	sanitizeAlephApiHosts,
+	verifyAlephPlaywrightEndpoint
+} from '../../e2e/remote/aleph-provider-contract.mjs';
+
+describe('Aleph remote Playwright provider', () => {
+	it('keeps api2 then api and removes api3 and arbitrary caller hosts', () => {
+		expect(
+			sanitizeAlephApiHosts('https://api3.aleph.im, https://api.aleph.im, https://evil.test')
+		).toEqual(ALEPH_API_HOSTS);
+		expect(sanitizeAlephApiHosts('https://api3.aleph.im')).toEqual(ALEPH_API_HOSTS);
+	});
+
+	it('fails fast on a client/server version mismatch', () => {
+		expect(() => assertPlaywrightVersion('1.60.0')).toThrow(/version mismatch.*1\.61\.1/iu);
+	});
+
+	it('uses Bearer auth when checking the pinned server version', async () => {
+		/** @type {HeadersInit | undefined} */
+		let observedHeaders;
+		/** @param {string | URL | Request} _url @param {RequestInit} [options] */
+		async function fetchImpl(_url, options) {
+			observedHeaders = options?.headers;
+			return new Response(JSON.stringify({ playwrightVersion: '1.61.1' }), { status: 200 });
+		}
+		const headers = await verifyAlephPlaywrightEndpoint({
+			versionUrl: 'https://runner.example/version',
+			secret: 'per-run-secret',
+			fetchImpl
+		});
+		expect(headers).toEqual({ authorization: 'Bearer per-run-secret' });
+		expect(observedHeaders).toEqual(headers);
+	});
+
+	it('passes Bearer auth in the Playwright 1.61 connect options', async () => {
+		let observedEndpoint;
+		let observedOptions;
+		const browser = { close() {} };
+		const result = await connectWithPlaywrightHeaders(
+			async (endpoint, options) => {
+				observedEndpoint = endpoint;
+				observedOptions = options;
+				return browser;
+			},
+			'wss://runner.example',
+			{ authorization: 'Bearer per-run-secret' }
+		);
+
+		expect(result).toBe(browser);
+		expect(observedEndpoint).toBe('wss://runner.example');
+		expect(observedOptions).toEqual({
+			headers: { authorization: 'Bearer per-run-secret' },
+			timeout: 120_000
+		});
+	});
+});


### PR DESCRIPTION
Ports `main`'s shared `@le-space/playwright` testkit **and** Aleph Phase-B cross-host remote-replication onto the **collab01 chapter**, adapted to its Spanish-mnemonic shared-list model.

> Tutorial chapters stay separate — this targets `collab01`, **not** `main`.

## Provisioning E2E (`relay-button-provisioning.spec.js`)
- Inline wallet/provision/cleanup/evidence → testkit (`createRelayTest` / `relayLifecycle.provision` / `installEip1193WalletMock` / `cleanupRelay` + evidence helpers). Default 0.6.35 driver is label-aware — no override.
- **Chapter core preserved:** consent-modal shared-list gate, `generateSpanishMnemonic`, `agent.open(mnemonic)`, `databaseName === sharedMnemonic` assertion, optional `2n6.me /health` check, concurrent two-browser relay dial.

## Remote replication (`e2e/remote/*`)
- `agent.mjs`: main's `remoteProgress` + streaming console + retryable `createTodo`, grafted with `open(mnemonic)` and `databaseName` in `diagnostics()`.
- `main-scenario.mjs`: main's **relay-mediated** success criterion (best-effort direct dial, gate on `waitForDatabaseSyncPeer` + actual replication) + mnemonic graft.
- `run-main.mjs`/`providers.mjs`: main's `aleph` provider path + shared-mnemonic summary row.
- New Aleph Phase-B toolchain copied from main: `aleph-provider-contract.mjs`, `aleph-guest-proxy.mjs`, seven `scripts/*aleph-playwright*` files, the `aleph-playwright-janitor` workflow, provider unit test.

## Workflows & deps
- `relay-button-e2e.yml` + `remote-replication.yml` aligned to main (Phase-B, provider default `aleph`), keeping collab01's `[main, collab01]` branch filter.
- `package.json`: + `@le-space/playwright@0.6.35`; pin `playwright`/`@playwright/test` to `1.61.1` (Aleph provider asserts exact version).

## Verified locally
`playwright --list` collects; vitest 24/24 (incl. copied aleph provider test); eslint + prettier clean; frozen-lockfile consistent. Real E2E needs the Aleph key → CI validation next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)