### PR TITLE
docs: frame README as the tutorial's main chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# Simple Todo - A Local-First Peer-to-Peer Demo App
+# Simple Todo - A Local-First Peer-to-Peer PWA Tutorial
 
 [![Main E2E](https://github.com/NiKrause/simple-todo/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/NiKrause/simple-todo/actions/workflows/deploy.yml?query=branch%3Amain)
 [![TestingBot Remote E2E](https://github.com/NiKrause/simple-todo/actions/workflows/remote-replication.yml/badge.svg?branch=main)](https://github.com/NiKrause/simple-todo/actions/workflows/remote-replication.yml)
 
 A basic decentralized, local-first, peer-to-peer todo application built with **libp2p**, **IPFS**, and **OrbitDB**. This app demonstrates how modern Web3 technologies can create truly decentralized applications that work entirely in the browser.
+
+> 📚 **This repository is a tutorial.** Its branches — `main`, `collab01`, `collab02` — are chapters that build the app up step by step, so they are kept separate rather than merged into one another. This is the `main` chapter (the basic local-first PWA).
 
 ## 🚀 Live Demo
 


### PR DESCRIPTION
Reflects the new repo description (*a local-first peer-to-peer PWA tutorial*): retitles the README to `… PWA Tutorial` and adds a one-line note that the branches (`main`, `collab01`, `collab02`) are tutorial chapters kept separate. Light-touch, `main` chapter only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)