### PR TITLE
docs: frame collab02 README as a tutorial chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Simple Todo - A Local-First Peer-to-Peer Demo App
+# Simple Todo - A Local-First Peer-to-Peer PWA Tutorial
 
 A basic decentralized, local-first, peer-to-peer todo application built with **libp2p**, **IPFS**, and **OrbitDB**. This app demonstrates how modern Web3 technologies can create truly decentralized applications that work entirely in the browser.
+
+> 📚 **This repository is a tutorial.** Its branches — `main`, `collab01`, `collab02` — are chapters that build the app up step by step, so they are kept separate rather than merged into one another. This is the `collab02` chapter (explicit OrbitDB-address collaboration).
 
 ## 🚀 Live Demo
 


### PR DESCRIPTION
Reflects the repo description (*a local-first peer-to-peer PWA tutorial*): retitles to `… PWA Tutorial` and notes the tutorial-chapter structure. Targets `collab02`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)