### PR TITLE
fix(collab01): profile-scope Aleph relay discovery (unblocks Phase-B replication)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"@helia/libp2p": "^1.0.5",
 		"@ipld/dag-cbor": "^10.0.1",
 		"@ipld/dag-json": "^11.0.0",
-		"@le-space/aleph-bootstrap": "^0.6.26",
+		"@le-space/aleph-bootstrap": "0.6.35",
 		"@le-space/orbitdb-identity-provider-webauthn-did": "0.3.1",
 		"@le-space/ui": "^0.6.26",
 		"@libp2p/autonat": "^3.0.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       '@le-space/aleph-bootstrap':
-        specifier: ^0.6.26
-        version: 0.6.26(typescript@5.9.2)
+        specifier: 0.6.35
+        version: 0.6.35(typescript@5.9.2)
       '@le-space/orbitdb-identity-provider-webauthn-did':
         specifier: 0.3.1
         version: 0.3.1(@orbitdb/core@4.0.0)(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))

--- a/scripts/resolve-aleph-bootstrap.mjs
+++ b/scripts/resolve-aleph-bootstrap.mjs
@@ -78,9 +78,16 @@ async function verifyBootstrapMultiaddrs(addresses) {
 const override = process.env.RELAY_BOOTSTRAP_OVERRIDE?.trim() || '';
 const fallback = process.env.RELAY_BOOTSTRAP_FALLBACK?.trim() || '';
 
+// Multiple relay implementations register in the same Aleph channel
+// (`orbitdb-relay` for simple-todo, `uc-go-peer` for universal-connectivity).
+// Scope discovery to our own profile so the build never bakes in a relay the
+// browsers cannot form a shared circuit with (a `uc-go-peer` relay leaves two
+// orbitdb browsers stuck at `candidates: 0`).
+const profile = process.env.RELAY_BOOTSTRAP_PROFILE?.trim() || 'orbitdb-relay';
+
 let resolution = resolveBootstrapMultiaddrs({ override, fallback });
 if (resolution.source !== 'override') {
-	const discovered = await discoverAlephBootstrapMultiaddrs({ browserDialableOnly: true });
+	const discovered = await discoverAlephBootstrapMultiaddrs({ browserDialableOnly: true, profile });
 	resolution = resolveBootstrapMultiaddrs({ override, discovered, fallback });
 }
 

--- a/src/lib/ManualConnectForm.svelte
+++ b/src/lib/ManualConnectForm.svelte
@@ -56,7 +56,13 @@
 			}
 
 			const { discoverAlephBootstrapMultiaddrs } = await import('@le-space/aleph-bootstrap');
-			const discovered = await discoverAlephBootstrapMultiaddrs({ browserDialableOnly: true });
+			// Scope discovery to our relay profile — the Aleph channel is shared
+			// with other profiles (e.g. universal-connectivity's `uc-go-peer`),
+			// whose relays leave two orbitdb browsers stuck at `candidates: 0`.
+			const discovered = await discoverAlephBootstrapMultiaddrs({
+				browserDialableOnly: true,
+				profile: import.meta.env.VITE_RELAY_BOOTSTRAP_PROFILE || 'orbitdb-relay'
+			});
 			const candidates = selectValidBrowserBootstrapMultiaddrs(discovered);
 			discoveredAddressCount = candidates.length;
 			const probeResults = await Promise.all(


### PR DESCRIPTION
collab01's cross-host remote-replication (Phase B) failed at `waitForDatabaseSyncPeer`: the two browsers discovered the shared Aleph channel **profile-blind** and never converged on a common relay (a `uc-go-peer` relay grants no orbitdb browser circuit → `candidates:0`). Same root cause `main` fixed in #47; collab01 never got it.

- `@le-space/aleph-bootstrap` `^0.6.26 → 0.6.35` (profile filter landed in 0.6.34).
- `resolve-aleph-bootstrap.mjs` + `ManualConnectForm.svelte`: pass `profile: 'orbitdb-relay'` (env-overridable). The deploy bakes the profile-scoped snapshot, so the deployed collab01 app auto-connects only to reachable orbitdb relays.

Backward-compatible; the app only uses `discoverAlephBootstrapMultiaddrs` from the package (API-compatible across the bump). Unit tests 24/24, frozen-lockfile consistent. After merge, collab01 re-deploys and the Phase-B cross-host run should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)