### PR TITLE
fix(deploy): link the production domain on manual main deploys too

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,8 @@ on:
       domain:
         description: >-
           Aleph custom domain to link (e.g. simple-todo.le-space.de).
-          Leave empty to skip domain linking.
+          Leave empty to use the default: runs on main always link
+          simple-todo.le-space.de, runs on other refs skip domain linking.
         required: false
         default: ''
 
@@ -154,7 +155,11 @@ jobs:
     env:
       # Only a push of the default branch may implicitly update production.
       # A manually dispatched feature branch must name its target explicitly.
-      ALEPH_MAIN_SITE_DOMAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'simple-todo.le-space.de' || '' }}
+      # Any deploy of main is a production deploy, so it must relink the domain —
+      # a manual run used to publish the new build to IPFS and then silently skip
+      # the link step, leaving simple-todo.le-space.de pinned to the previous CID
+      # while the run still reported success. `domain` still overrides this.
+      ALEPH_MAIN_SITE_DOMAIN: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'simple-todo.le-space.de' || '' }}
     steps:
       - name: Checkout simple-todo
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

Ein `workflow_dispatch`-Deploy auf `main` hat den neuen Build nach Aleph IPFS publiziert und den Schritt **„Link custom domain" still übersprungen** — und trotzdem **„success"** gemeldet.

Grund: `ALEPH_MAIN_SITE_DOMAIN` wurde nur bei `push` gesetzt:

```yaml
ALEPH_MAIN_SITE_DOMAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && '…' || '' }}
# Link-Schritt:
if: inputs.domain != '' || env.ALEPH_MAIN_SITE_DOMAIN != ''
```

Bei manuellem Start ohne `domain`-Input waren **beide** leer → Schritt übersprungen → die DNSLink zeigte weiter auf den **alten** CID.

## Auswirkung (real passiert)

`simple-todo.le-space.de` lieferte weiter einen Build aus, der einen **nicht mehr existierenden Relay** eingebacken hatte. Dadurch scheiterte **jeder** remote-replication-Lauf schon beim Verbindungsaufbau (`net::ERR_CONNECTION_CLOSED`, Timeout in `verifying-relays`) — während der Deploy-Lauf grün aussah. Das hat mehrfach zu Fehlsuchen geführt.

## Fix

Jeder Deploy von `main` ist ein Produktions-Deploy und muss die Domain neu verlinken — also `ALEPH_MAIN_SITE_DOMAIN` auch für `workflow_dispatch` auf `main` setzen.

- Der explizite `domain`-Input **überschreibt** weiterhin
- Läufe auf anderen Refs überspringen das Verlinken wie bisher
- Input-Beschreibung entsprechend präzisiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)