### PR TITLE
feat(e2e): fail fast when the pinned rootfs is gone from Aleph

### DIFF
--- a/.github/workflows/relay-button-e2e.yml
+++ b/.github/workflows/relay-button-e2e.yml
@@ -35,6 +35,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Require relay deployment credentials
         run: test -n "$RELAY_BUTTON_E2E_PRIVATE_KEY" && test -n "$RELAY_BUTTON_E2E_SSH_PUBLIC_KEY"
+      # Fail in seconds with an actionable message when the pinned rootfs was
+      # pruned from Aleph, instead of burning ~14 minutes on a provisioning run
+      # that ends in a bare "Aleph rejected this deployment (error 301)".
+      - name: Verify the pinned rootfs still exists on Aleph
+        run: node scripts/check-rootfs-manifest.mjs
       - name: Provision relay and verify two-browser replication
         run: pnpm exec playwright test e2e/relay-button-provisioning.spec.js --project=chromium --workers=1 --reporter=list
       - name: Write relay E2E job summary

--- a/scripts/check-rootfs-manifest.mjs
+++ b/scripts/check-rootfs-manifest.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Fails fast when `static/rootfs-manifest.json` points at a rootfs image that no
+ * longer exists on Aleph.
+ *
+ * The Relay Button provisions real relays from that manifest. When the
+ * referenced STORE message is pruned or forgotten, the deploy is rejected deep
+ * inside the Aleph tooling with a bare `error 301 — Referenced message(s): …`,
+ * which reads like an infrastructure outage rather than a stale pin. Checking it
+ * up front turns that into an actionable message.
+ */
+import { readFile } from 'node:fs/promises';
+
+const MANIFEST_PATH = process.env.ROOTFS_MANIFEST_PATH || 'static/rootfs-manifest.json';
+const API_HOSTS = (process.env.ALEPH_API_HOSTS || 'https://api2.aleph.im,https://api.aleph.im')
+	.split(',')
+	.map((host) => host.trim())
+	.filter(Boolean);
+const TIMEOUT_MS = Number(process.env.ROOTFS_MANIFEST_CHECK_TIMEOUT_MS || 15_000);
+
+const ITEM_HASH_RE = /^[a-f0-9]{64}$/iu;
+
+const manifest = JSON.parse(await readFile(MANIFEST_PATH, 'utf8'));
+const { rootfsItemHash, rootfsCid, version, profile } = manifest;
+
+if (!ITEM_HASH_RE.test(rootfsItemHash ?? '')) {
+	throw new Error(
+		`${MANIFEST_PATH}: rootfsItemHash must be a 64 character hex value, got ${JSON.stringify(rootfsItemHash)}`
+	);
+}
+
+/**
+ * @param {string} apiHost
+ * @returns {Promise<{ found: boolean, detail: string }>}
+ */
+async function lookup(apiHost) {
+	const url = new URL('/api/v0/messages.json', apiHost);
+	url.searchParams.set('hashes', rootfsItemHash);
+	const response = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+	if (!response.ok) return { found: false, detail: `HTTP ${response.status}` };
+	const payload = await response.json();
+	const message = payload.messages?.[0];
+	if (!message) return { found: false, detail: 'no STORE message returned' };
+	if (message.type !== 'STORE') return { found: false, detail: `unexpected type ${message.type}` };
+	return { found: true, detail: `STORE, item_type=${message.content?.item_type ?? 'unknown'}` };
+}
+
+const observations = [];
+for (const apiHost of API_HOSTS) {
+	try {
+		const result = await lookup(apiHost);
+		if (result.found) {
+			console.log(
+				`✓ rootfs ${rootfsItemHash.slice(0, 12)}… (${profile} ${version}) is available on Aleph — ${result.detail} via ${apiHost}`
+			);
+			process.exit(0);
+		}
+		observations.push(`${apiHost}: ${result.detail}`);
+	} catch (error) {
+		observations.push(`${apiHost}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+throw new Error(
+	[
+		`Rootfs referenced by ${MANIFEST_PATH} is gone from Aleph.`,
+		`  rootfsItemHash: ${rootfsItemHash}`,
+		`  rootfsCid:      ${rootfsCid}`,
+		`  version:        ${profile} ${version}`,
+		'',
+		'Every Relay Button provisioning will fail with "Aleph rejected this deployment',
+		'(error 301)" until the manifest is bumped to a rootfs that is still published.',
+		'Publish a fresh rootfs (orbitdb-relay "Aleph Rootfs Build, Publish & Deploy")',
+		'and update the manifest with the new rootfsItemHash/rootfsCid.',
+		'',
+		`Checked: ${observations.join(' | ')}`
+	].join('\n')
+);


### PR DESCRIPTION
## Problem

Der Relay-Button provisioniert echte Relays aus `static/rootfs-manifest.json`. Wenn das referenzierte STORE-Message auf Aleph weggeräumt wurde, lehnt die Aleph-Tooling den Deploy **mitten im Provisioning-Lauf** ab — mit nichts als:

```
Aleph rejected this deployment (error 301). Referenced message(s): f50d5005…
```

Das liest sich wie ein Infrastruktur-Ausfall, ist aber schlicht ein veralteter Pin. Heute hat uns genau das **zwei lange Fehlsuchen** gekostet, und der relay-button-E2E verbrennt dabei jedes Mal ~14 Minuten, bevor der Fehler überhaupt sichtbar wird.

## Fix

Ein Vorab-Check (`scripts/check-rootfs-manifest.mjs`), der in Sekunden fehlschlägt und Hash, Konsequenz und Lösungsweg nennt:

```
Rootfs referenced by static/rootfs-manifest.json is gone from Aleph.
  rootfsItemHash: f50d5005…
  rootfsCid:      Qm…
  version:        orbitdb-relay orbitdb-relay-v0.9.7

Every Relay Button provisioning will fail with "Aleph rejected this deployment
(error 301)" until the manifest is bumped to a rootfs that is still published.
Publish a fresh rootfs … and update the manifest with the new rootfsItemHash/rootfsCid.
```

Eingehängt in `relay-button-e2e.yml` direkt vor dem Provisioning-Schritt. Beide API-Hosts werden nacheinander probiert, damit ein einzelner Replica-Ausfall keinen falschen Alarm auslöst.

## Verifikation

- ✅ grün gegen das aktuell lebende Rootfs `ea2577d2…` (`exit 0`)
- ✅ klarer Fehler gegen das tote `f50d5005…`

## Kontext

Das ist Schritt 3 aus dem Automatisierungsplan. Der eigentliche Automatisierungsschritt — die Manifest nicht mehr von Hand pflegen, sondern beim Build aus den Aleph-Deployment-Records auflösen — folgt separat; vorher muss noch geklärt werden, warum die orbitdb-relay-Records unter dem Aggregate-Key `uc-go-peer-successful-deployments` landen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)