### PR TITLE
chore(relay-button): bump rootfs to the DHT-disabled image cf8da104

### DIFF
--- a/static/rootfs-manifest.json
+++ b/static/rootfs-manifest.json
@@ -49,9 +49,9 @@
     }
   ],
   "rootfsSizeMiB": 20480,
-  "createdAt": "2026-07-21T21:34:01.364Z",
+  "createdAt": "2026-07-22T10:49:17.178Z",
   "notes": "The OrbitDB relay image prebakes Node.js, production dependencies, and Caddy into the qcow2, delays first relay start until Aleph host port mappings are known, exposes a temporary setup endpoint on port 80, and uses Caddy on port 443 to front both HTTPS helper routes and secure libp2p WSS transport for the configured proxy hostname.",
-  "rootfsSourceSizeBytes": 664478208,
-  "rootfsCid": "QmYr6webXEyyenSqJESQfHb8CmYqUyFwJ8XW2qKwM9kEhn",
-  "rootfsItemHash": "ea2577d2ed59da1382cf794e3819f89b4a545a95cbac3e8a520cfd7fb961ffa7"
+  "rootfsSourceSizeBytes": 662133760,
+  "rootfsCid": "QmeKjeMHPGc6uDARDcMHzVwTSiRumTjeXycoK9HaPDWC8G",
+  "rootfsItemHash": "cf8da104c5a010ee5986fa477da9a77f2b7345c540363ff4024a9714e3c02bdc"
 }


### PR DESCRIPTION
## Problem

Der Relay-Button provisionierte Relays aus Rootfs `ea2577d2…` — gebaut am 21.07., **bevor** der kad-DHT abgeschaltet wurde. Jeder so deployte Relay announcete sich in die öffentliche DHT, wurde mit eingehenden Verbindungen geflutet und hing binnen Minuten.

Ergebnis im relay-button-E2E: die beiden Browser kamen über **~10 Minuten** auf **keiner** der drei Adressen durch (`connected:[false,false]`), auch nicht über den Caddy-Proxy:

```
Error: browsers did not connect to relay 12D3KooWMA8gjBko3RfYnG3Cs2srvRiyAK3uPV9oz3eyvnpxCXcP
```

## Fix

Bump auf **`cf8da104…`** — das erste Image, das mit relay-button-Tooling `v0.6.22-autotls2` gebaut wurde und damit `RELAY_DISABLE_DHT=1` einbäckt (zusätzlich zu den AutoTLS-Fixes: Bootstrap aktiviert, IPv6 auf internen Listen-Ports).

| Feld | alt | neu |
|---|---|---|
| `rootfsItemHash` | `ea2577d2…` | **`cf8da104…`** |
| `rootfsCid` | `QmYr6webX…` | **`QmeKjeMHP…`** |
| `rootfsSourceSizeBytes` | 664478208 | 662133760 |
| `createdAt` | 2026-07-21T21:34 | 2026-07-22T10:49 |

Profile, Version, Install-Strategie und Port-Forwards bleiben unverändert.

## Verifikation

```
$ node scripts/check-rootfs-manifest.mjs
✓ rootfs cf8da104c5a0… (orbitdb-relay orbitdb-relay-v0.9.7) is available on Aleph — STORE, item_type=ipfs
```

## Auswirkung auf remote-replication: keine

Seit der Phase-B-Migration pinnt `remote-replication.yml` sein **eigenes** `playwright-runner`-Rootfs (`c392fba3…`) und liest diese Manifest nicht mehr. Einziger Konsument ist `SponsorRelayFab` in `src/routes/+page.svelte` — also der Relay-Button-Pfad.

Der Rootfs-Build lief bewusst mit `deploy_vm=false`, damit der laufende Relay `urge-gym-circle-excuse` (auf dem remote-replication gerade grün ist) unangetastet bleibt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)