### PR TITLE
ci(collab01): run preview replication against Aleph instead of TestingBot

### DIFF
--- a/.github/workflows/deploy-issue33.yml
+++ b/.github/workflows/deploy-issue33.yml
@@ -114,7 +114,7 @@ jobs:
     needs: link-domain
     runs-on: ubuntu-latest
     steps:
-      - name: Start TestingBot replication against the preview
+      - name: Start remote replication against the preview
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
@@ -122,4 +122,4 @@ jobs:
           --repo "${{ github.repository }}"
           --ref collab01
           -f app_url=https://collab01.le-space.de
-          -f provider=testingbot
+          -f provider=aleph


### PR DESCRIPTION
## Problem

Der Preview-Deploy startete remote-replication mit hartkodiertem `-f provider=testingbot`. Damit hing das Kapitel an einem kostenpflichtigen Fremddienst — der es gerade komplett blockiert hat:

```
You have no more TestingBot credits left. Please upgrade your plan.
wss://cloud.testingbot.com/playwright  →  400 Bad Request
```

## Fix

Umstellung auf den Aleph-Provider. Das bringt drei Dinge:

1. **Keine externe Guthaben-Abhängigkeit** mehr für den Kapitel-Lauf
2. **Konsistenz** — `remote-replication.yml` hat bei `workflow_call` *und* `workflow_dispatch` ohnehin schon `default: aleph`; nur dieser Aufruf wich ab. main nutzt ebenfalls `aleph`.
3. **Phase B wird überhaupt erst ausgeübt** — mit TestingBot als zweitem Browser blieb der gerade portierte Aleph-Playwright-Pfad vollständig ungetestet

TestingBot bleibt über den `workflow_dispatch`-Input weiterhin wählbar.

## Hinweis

Falls collab01 didaktisch **bewusst** den TestingBot-Weg zeigen soll, ist das der falsche PR — dann bitte zumachen und stattdessen das Guthaben aufladen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)