### PR TITLE
chore(collab01): align @le-space/ui with main (0.6.26 → 0.6.34)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"@ipld/dag-json": "^11.0.0",
 		"@le-space/aleph-bootstrap": "0.6.35",
 		"@le-space/orbitdb-identity-provider-webauthn-did": "0.3.1",
-		"@le-space/ui": "^0.6.26",
+		"@le-space/ui": "0.6.34",
 		"@libp2p/autonat": "^3.0.22",
 		"@libp2p/bootstrap": "^12.0.25",
 		"@libp2p/circuit-relay-v2": "^4.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: 0.3.1
         version: 0.3.1(@orbitdb/core@4.0.0)(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
       '@le-space/ui':
-        specifier: ^0.6.26
-        version: 0.6.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.37.2)(typescript@5.9.2)
+        specifier: 0.6.34
+        version: 0.6.34(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.37.2)(typescript@5.9.2)
       '@libp2p/autonat':
         specifier: ^3.0.22
         version: 3.0.22
@@ -972,17 +972,17 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@le-space/aleph-bootstrap@0.6.26':
-    resolution: {integrity: sha512-vFz8A0Ql8ylhHG7db9HRkByBYtHKzV7R0CXVX2ST/KqBjeAGMPKsVZoJfRdfZQ9AnmGGNgY5L54n6D2VoQ2cVA==}
+  '@le-space/aleph-bootstrap@0.6.34':
+    resolution: {integrity: sha512-Zb2Ew/Hbi2e6zW0tcD3586twtQvdNmLECa2eDjPw5JeMU4QVrtJyQTcgSBhP1yYUX8fBJIAmK8jZD/cSxgFtcg==}
 
   '@le-space/aleph-bootstrap@0.6.35':
     resolution: {integrity: sha512-jCEmQRHOM2P46r/ISfQGQ/YRNUNMlVo27VtdKVl5vutSFdsoXLEEB/h7ilVwBAEsz9zZH51Uy9x660xjYk0cog==}
 
-  '@le-space/browser@0.6.26':
-    resolution: {integrity: sha512-p/2mkXQJJImpa9Bc5vE2BSIyIB4N/klyx2ORH2pWTpa720WabeSYERd1PJum67nptlpn1vFecYizDAihonTVSQ==}
+  '@le-space/browser@0.6.34':
+    resolution: {integrity: sha512-lD6OXw5y0csU+TRPHqJJb+QkU4AY+pxV0XQw0+Jd5GfF+sjY+uYvhnSndqwY5gLXKguLPCwzLJf6yjh4OKnhNg==}
 
-  '@le-space/core@0.6.26':
-    resolution: {integrity: sha512-hCXu8AcU1CjodMd1iHpf6B5c/NaWupFIE6Ym+/NV5Aav3OK/l8zKimFeYCG2JPGHSwk04ksW3Pv3hqg2+0q5tQ==}
+  '@le-space/core@0.6.34':
+    resolution: {integrity: sha512-NCiYl/wPciEZYWYhb+q+j4K3tjDdFIvwB/ieqxzyuBLSoSzh1GZ0slts7Zcy9W21lt/G0lVEbcNa+x4BQFnIiw==}
 
   '@le-space/core@0.6.35':
     resolution: {integrity: sha512-8jjGKyiByJ9U7NpCv825J63k7VbF5okAU0JS0cOLziCdcPMPtpF3E9ZV4f67jGr4w4BcdOPGBAIX4nb+3XueEw==}
@@ -1023,8 +1023,8 @@ packages:
   '@le-space/rootfs@0.6.35':
     resolution: {integrity: sha512-lK1RZ88Xcxx1bwfvGtVYhno/yFlVsfflwvejUc1TPnQKSGteSikYuClxCCXdI5Hv7Vx7JSFTWIs2LrK4xp55kw==}
 
-  '@le-space/shared-types@0.6.26':
-    resolution: {integrity: sha512-Kw+avCoxyOKKFhqUn7GJChvW0XNxqCgcBwXZeBuGqA+R9ixC0SN12FxqSE0akC1lsZ0XTYNvNTsC3xYbz4OxdQ==}
+  '@le-space/shared-types@0.6.34':
+    resolution: {integrity: sha512-r338xuFO+mw9/9EcNw2d+se1UDklw4Ek7pBW4kKaEgZHk8pRQHZVXipiBgNqCW6UVSCAzt8Ak3HZtKtl/0RkHw==}
 
   '@le-space/shared-types@0.6.35':
     resolution: {integrity: sha512-xIdEQ6WHb063uj9ixagno1GdxCvHjNXgScJttZS1kZN2z0X+50kRIitWzL3RQpQIRXMLyHiuharw/j5jZCZeZg==}
@@ -1038,8 +1038,8 @@ packages:
   '@le-space/ucanto-principal@9.1.2':
     resolution: {integrity: sha512-vWRXFPLKQwfC7CXhgrl3p11cOgEWHcgQyosR4EztgKfHmKAbYOn2y7VQpr4pEtJHw/iB92EJSyJBGYecTmF/2g==}
 
-  '@le-space/ui@0.6.26':
-    resolution: {integrity: sha512-otyqEVHy/7ILKfNPGC1JLqNniX+GP1L10X76YIkvTEfPkR/FnyEkAqb1TPRcMBmjY5+pCNso3wFt+JaDdlGY/w==}
+  '@le-space/ui@0.6.34':
+    resolution: {integrity: sha512-sH96wydAsbe8OHgnQGa/szZYWd8LE/kB707pPKxY6dokMaZfsKwbEZJDivxtBODfIQU5zpLAnA8CilJRQguZhQ==}
     peerDependencies:
       react: 19.2.6
       react-dom: 19.2.6
@@ -6392,7 +6392,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@le-space/aleph-bootstrap@0.6.26(typescript@5.9.2)':
+  '@le-space/aleph-bootstrap@0.6.34(typescript@5.9.2)':
     dependencies:
       '@libp2p/bootstrap': 11.0.47
       viem: 2.53.1(typescript@5.9.2)
@@ -6412,12 +6412,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@le-space/browser@0.6.26': {}
+  '@le-space/browser@0.6.34': {}
 
-  '@le-space/core@0.6.26(typescript@5.9.2)':
+  '@le-space/core@0.6.34(typescript@5.9.2)':
     dependencies:
-      '@le-space/aleph-bootstrap': 0.6.26(typescript@5.9.2)
-      '@le-space/shared-types': 0.6.26
+      '@le-space/aleph-bootstrap': 0.6.34(typescript@5.9.2)
+      '@le-space/shared-types': 0.6.34
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -6547,7 +6547,7 @@ snapshots:
 
   '@le-space/rootfs@0.6.35': {}
 
-  '@le-space/shared-types@0.6.26': {}
+  '@le-space/shared-types@0.6.34': {}
 
   '@le-space/shared-types@0.6.35': {}
 
@@ -6574,10 +6574,10 @@ snapshots:
       multiformats: 13.4.2
       one-webcrypto: 1.0.3
 
-  '@le-space/ui@0.6.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.37.2)(typescript@5.9.2)':
+  '@le-space/ui@0.6.34(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.37.2)(typescript@5.9.2)':
     dependencies:
-      '@le-space/browser': 0.6.26
-      '@le-space/core': 0.6.26(typescript@5.9.2)
+      '@le-space/browser': 0.6.34
+      '@le-space/core': 0.6.34(typescript@5.9.2)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       svelte: 5.37.2
@@ -6689,7 +6689,7 @@ snapshots:
       '@libp2p/interface': 3.2.5
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
-      multiformats: 14.0.3
+      multiformats: 14.0.4
       protons-runtime: 7.0.0
       uint8arraylist: 3.0.2
       uint8arrays: 6.1.1


### PR DESCRIPTION
## Problem

Der relay-button-E2E lehnt das aktuelle Rootfs mit „manifest rootfs not deployable" ab — obwohl die UI im selben Lauf meldet:

```
[le-space/ui] refresh:success {manifestValid: true, rootfsVerified: true, instances: 0}
```

Das Rootfs ist also **in Ordnung**; die alte UI 0.6.26 leitet daraus nur nicht den Status „deployable" ab (ihre Logik fällt in den Fallthrough statt in den Ready- oder Pending-Zweig).

## Empirische Matrix

| Rootfs | UI | Ergebnis |
|---|---|---|
| `f50d5005` (alt) | 0.6.26 | ✅ grün (collab01, 21.07. 16:35) |
| `cf8da104` (neu) | **0.6.26** | ❌ „not deployable" |
| `cf8da104` (neu) | **0.6.34** | ✅ grün (main, heute) |

Der Fehler tritt ausschließlich in der Kombination **neues Rootfs + alte UI** auf.

## Fix

`@le-space/ui` auf **0.6.34** — genau die Version, mit der main dasselbe Rootfs und dasselbe Testkit grün fährt. Die Drift stammt aus der Testkit-Übernahme (#51): dort wurde `@le-space/playwright` auf 0.6.35 gezogen, die UI aber auf `^0.6.26` belassen.

## Verifikation

- ✅ pnpm löst 0.6.34 auf
- ✅ Produktions-Build läuft durch (`✓ built in 22.60s`)
- ✅ `SponsorRelayFab`-Verwendung im Kapitel unverändert und identisch mit main (`manifestUrl` + `showInstances`) — kein API-Bruch über den Sprung

## Hinweis

Das ist bewusst eine **Kapitel-Abhängigkeit**. Falls collab01 didaktisch auf 0.6.26 festgenagelt bleiben soll, ist das der falsche PR — dann bliebe der relay-button-E2E dort allerdings dauerhaft rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)