### PR TITLE
fix(e2e): gate cross-network replication on the todo, not a pre-todo sync peer

### DIFF
--- a/e2e/remote/main-scenario.mjs
+++ b/e2e/remote/main-scenario.mjs
@@ -51,7 +51,10 @@ export async function runMainRemoteScenario({
 		result.evidence.stage = stage;
 		remoteProgress(`stage: ${stage}${detail ? ` (${detail})` : ''}`);
 	};
-	setStage('opening-browsers', `provider=${remoteProvider}, requirePublicRelay=${requirePublicRelay}`);
+	setStage(
+		'opening-browsers',
+		`provider=${remoteProvider}, requirePublicRelay=${requirePublicRelay}`
+	);
 
 	await mkdir(outputDir, { recursive: true });
 
@@ -111,8 +114,8 @@ export async function runMainRemoteScenario({
 		// (`runOnLimitedConnection: true`), so the todo replicates relay-mediated
 		// even when the (slower/absent) direct dial never completes — proven by
 		// the UC cross-host run (<0.3 s over a single relay). Attempt the direct
-		// connection best-effort, then gate on the real signals: a database sync
-		// peer and the todo actually replicating.
+		// connection best-effort, then gate on the real signal: the todo actually
+		// replicating.
 		setStage('connecting-browser-peers');
 		const addressForB = selectPeerDialAddress(result.agents.b, result.agents.b.peerId, {
 			requirePublic: requirePublicRelay
@@ -135,7 +138,26 @@ export async function runMainRemoteScenario({
 				`agent B advertised no direct dial address for ${result.agents.b.peerId}; relying on relay-mediated replication`
 			);
 		}
-		await Promise.all([agentA.waitForDatabaseSyncPeer(), agentB.waitForDatabaseSyncPeer()]);
+		// Do NOT hard-gate on a database sync peer before the first todo exists.
+		// The relay only joins a database when the app's replication-proof flow
+		// runs on a todo (POST /pinning/sync in verifyRelayReplication) — so on a
+		// fresh database (or a freshly redeployed relay with an empty datastore)
+		// the only pre-todo path to a sync peer is the best-effort direct dial
+		// above, which routinely fails between NAT'd CI browsers. That made this
+		// stage fail deterministically on collab01 (fresh mnemonic database every
+		// run) and sporadically on main right after relay redeploys. Probe briefly
+		// for the fast path, then let the replication assertions below be the real
+		// gate: creating the first todo triggers the relay join, and waitForTodo
+		// proves the mesh either way.
+		const earlySyncPeers = await Promise.allSettled([
+			agentA.waitForDatabaseSyncPeer(30_000),
+			agentB.waitForDatabaseSyncPeer(30_000)
+		]);
+		remoteProgress(
+			`pre-todo database sync peers (informational): agentA=${
+				earlySyncPeers[0].status === 'fulfilled' ? 'yes' : 'not yet'
+			} agentB=${earlySyncPeers[1].status === 'fulfilled' ? 'yes' : 'not yet'}`
+		);
 		result.agents.a = await agentA.diagnostics();
 		result.agents.b = await agentB.diagnostics();
 


### PR DESCRIPTION
## Problem

Das Remote-Szenario verlangte für beide Browser einen `waitForDatabaseSyncPeer` **bevor** das erste Todo existiert. Der Relay tritt einer Datenbank aber erst bei, wenn der App-eigene Proof-Flow auf einem Todo läuft (`POST /pinning/sync` in `verifyRelayReplication`). Auf einer frischen Datenbank — oder einem frisch redeployten Relay mit leerem Datastore — bleibt vor dem ersten Todo als einziger Weg zum Sync-Peer die direkte Browser-zu-Browser-Verbindung, die das Szenario selbst als `(best-effort)` markiert und die zwischen NAT-CI-Browsern regelmäßig scheitert.

## Evidenz

| Kontext | `connecting-browser-peers` |
|---|---|
| collab01, frische Mnemonic-DB pro Lauf | ❌ **3 von 3** |
| main, direkt nach Relay-Redeploy (29907733700) | ❌ |
| main, Relay kannte die geteilte DB (29909330945) | ✅ — bidirektional relay-vermittelt in 6,6 s / 1,9 s |

## Fix (nur Test-Schicht)

- Hartes Gate → **30-s-informative Probe** (`pre-todo database sync peers (informational): agentA=yes/not yet …`) — erhält Fast-Path und Diagnose
- Echtes Gate ist die Replikation: `createTodo` löst den Relay-Beitritt über den App-eigenen Flow aus, `waitForTodo` beweist das Mesh
- Spiegelt exakt den realen Nutzerpfad — kein Nutzer braucht je einen Sync-Peer vor seinem ersten Todo

**Kein Tutorial-App-Code angefasst** — der vorige Versuch, das in `src/lib/db-actions.js` zu lösen (#63), brach den lokalen Collaboration-E2E und wurde revertiert (#64).

## Validierung

Wird per `workflow_dispatch` von remote-replication **auf diesem Branch** vor dem Merge gegengetestet; nach dem Merge chirurgische Portierung nach collab01, wo der bislang deterministisch rote Fall den eigentlichen Beweis liefert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)