### PR TITLE
feat(e2e): make gossipsub topic and mesh state observable in diagnostics

### DIFF
--- a/e2e/remote/agent.mjs
+++ b/e2e/remote/agent.mjs
@@ -78,6 +78,7 @@ export class TodoBrowserAgent {
 				databasePeers: diagnostics?.getDatabasePeers?.() ?? [],
 				multiaddrs: diagnostics?.getMultiaddrs?.() ?? [],
 				connections: diagnostics?.getConnections?.() ?? [],
+				pubsub: diagnostics?.getPubsubState?.() ?? null,
 				appStamp: document.querySelector('header p')?.textContent?.trim() ?? null,
 				userAgent: navigator.userAgent
 			};

--- a/e2e/remote/main-scenario.mjs
+++ b/e2e/remote/main-scenario.mjs
@@ -160,6 +160,33 @@ export async function runMainRemoteScenario({
 		);
 		result.agents.a = await agentA.diagnostics();
 		result.agents.b = await agentB.diagnostics();
+		// Condensed pubsub view per agent: whether the database topic is
+		// subscribed and who sits in its gossipsub mesh. Live head propagation
+		// depends on exactly this, and it has failed while everything else
+		// (connections, sync peers, relay pinning) looked healthy.
+		for (const [label, agent] of [
+			['agentA', result.agents.a],
+			['agentB', result.agents.b]
+		]) {
+			const pubsub = agent.pubsub;
+			if (!pubsub) {
+				remoteProgress(`${label} pubsub state: unavailable (older app build?)`);
+				continue;
+			}
+			const dbTopic = pubsub.topics.find((topic) => topic.includes('/orbitdb/')) ?? null;
+			remoteProgress(
+				`${label} pubsub: topics=${pubsub.topics.length} peers=[${pubsub.peers
+					.map((peer) => peer.slice(-6))
+					.join(',')}] dbTopic=${dbTopic ? 'subscribed' : 'MISSING'} dbMesh=[${(
+					(dbTopic && pubsub.mesh[dbTopic]) ||
+					[]
+				)
+					.map((peer) => peer.slice(-6))
+					.join(',')}] dbSubscribers=[${((dbTopic && pubsub.subscribers[dbTopic]) || [])
+					.map((peer) => peer.slice(-6))
+					.join(',')}]`
+			);
+		}
 
 		setStage('creating-todo-on-agent-a');
 		const aToBStarted = Date.now();

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -301,7 +301,34 @@ function getReadOnlyDiagnostics() {
 			libp2p?.getConnections?.().map((/** @type {any} */ connection) => ({
 				remotePeer: connection.remotePeer?.toString() ?? null,
 				remoteAddr: connection.remoteAddr?.toString() ?? null
-			})) ?? []
+			})) ?? [],
+		// Read-only gossipsub introspection for the remote-replication E2E: live
+		// head propagation runs over pubsub on the database topic, and a run has
+		// shown both browsers fully synced and relay-joined while the freshly
+		// created entry still never arrived. These getters make the topic
+		// subscriptions and the gossipsub mesh observable from the test so that
+		// failure mode is attributable instead of an opaque timeout.
+		getPubsubState: () => {
+			const pubsub = /** @type {any} */ (libp2p?.services?.pubsub);
+			if (!pubsub) return null;
+			const topics = pubsub.getTopics?.() ?? [];
+			return {
+				topics,
+				peers: (pubsub.getPeers?.() ?? []).map(String),
+				subscribers: Object.fromEntries(
+					topics.map((/** @type {string} */ topic) => [
+						topic,
+						(pubsub.getSubscribers?.(topic) ?? []).map(String)
+					])
+				),
+				mesh: Object.fromEntries(
+					Array.from(pubsub.mesh?.entries?.() ?? [], ([topic, peers]) => [
+						topic,
+						Array.from(peers ?? [], String)
+					])
+				)
+			};
+		}
 	};
 }
 


### PR DESCRIPTION
## Kontext

Lauf 29920672144 hat den verbleibenden cross-network-Fehler auf die **Live-Head-Propagation** eingegrenzt: beide Browser vollständig gesynct (B hielt die komplette 9-Entry-Historie), beide mit dem Relay als DB-Sync-Peer, sogar eine direkte WebRTC-Verbindung A↔B stand, und der Relay hatte das neue Entry nachweislich gepinnt (Proof verifiziert) — trotzdem erreichte das frisch erstellte Todo Agent B in 120 s nie.

Alles Messbare sah gesund aus. Die eine Schicht, die niemand beobachtet, ist **Pubsub** — genau dort läuft die Live-Head-Propagation.

## Änderung (rein Diagnose, kein Verhalten)

- **`src/lib/p2p.js`**: read-only `getPubsubState()` am bestehenden `__simpleTodoDiagnostics`-Hook — Topics, Pubsub-Peers, Subscriber pro Topic, gossipsub-Mesh. Der Hook existiert genau für diesen Zweck.
- **`e2e/remote/agent.mjs`**: `diagnostics()` sammelt den Zustand mit ein → landet bei Fehlschlag in `result.json`
- **`e2e/remote/main-scenario.mjs`**: kompakte Zeile pro Agent vor dem ersten Todo:
  ```
  agentB pubsub: topics=2 peers=[…y1WJ4n] dbTopic=subscribed dbMesh=[…] dbSubscribers=[…]
  ```

Relay-seitig ist `libp2p:gossipsub*`-Debug auf dem Live-Relay bereits aktiv — die nächste Fehlschlag-Instanz ist damit von beiden Seiten belegbar.

## Validierung

`node --check`, Prettier, ESLint, Build sauber. Der lokale Collaboration-E2E läuft in der PR-CI als Gate (Lehre aus #63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)