### PR TITLE
chore(relay-button): bump rootfs to be595acb (gossipsub 16.0.5 relay stack)

### DIFF
--- a/static/rootfs-manifest.json
+++ b/static/rootfs-manifest.json
@@ -49,9 +49,9 @@
     }
   ],
   "rootfsSizeMiB": 20480,
-  "createdAt": "2026-07-22T10:49:17.178Z",
+  "createdAt": "2026-07-22T13:36:10.702Z",
   "notes": "The OrbitDB relay image prebakes Node.js, production dependencies, and Caddy into the qcow2, delays first relay start until Aleph host port mappings are known, exposes a temporary setup endpoint on port 80, and uses Caddy on port 443 to front both HTTPS helper routes and secure libp2p WSS transport for the configured proxy hostname.",
-  "rootfsSourceSizeBytes": 662133760,
-  "rootfsCid": "QmeKjeMHPGc6uDARDcMHzVwTSiRumTjeXycoK9HaPDWC8G",
-  "rootfsItemHash": "cf8da104c5a010ee5986fa477da9a77f2b7345c540363ff4024a9714e3c02bdc"
+  "rootfsSourceSizeBytes": 663091200,
+  "rootfsCid": "QmRQUfeeCN4mbvwv6hxNGvvfAnTGUntEUNtrwdDWMLCyDi",
+  "rootfsItemHash": "be595acb45bc7bb1b3fea005e6ad679c7caea8e4fb1d8d432e01571374853174"
 }


### PR DESCRIPTION
## Was

Manifest-Bump auf das Image aus [orbitdb-relay#15](https://github.com/NiKrause/orbitdb-relay/pull/15) (Rootfs-Publish [29924013364](https://github.com/NiKrause/orbitdb-relay/actions/runs/29924013364), Tooling `v0.6.22-autotls2`).

| Feld | alt | neu |
|---|---|---|
| `rootfsItemHash` | `cf8da104…` | **`be595acb…`** |
| `rootfsCid` | `QmeKjeMHP…` | **`QmRQUfeeCN…`** |
| `rootfsSourceSizeBytes` | 662133760 | 663091200 |
| `createdAt` | 22.07. 10:49 | 22.07. 13:36 |

## Warum

Mesh-Grafting ist ein **beidseitiger** GRAFT/PRUNE-Austausch. Die instrumentierten Läufe zeigen: Auch nachdem die Browser auf gossipsub 16.0.5 sind, bleibt das DB-Topic-Mesh des Aleph-VM-Browsers leer — der Relay ist die andere Hälfte des Austauschs und läuft noch 16.0.3. Button-provisionierte Relays aus diesem Image sprechen die gefixte Validierung auch relay-seitig (dazu circuit-relay-v2 4.2.9: Reservation-Refresh-Leak — dieser Prozess bedient alle Browser-Reservations).

## Verifikation

```
✓ rootfs be595acb45bc… is available on Aleph — STORE, item_type=ipfs
```

Der laufende Produktions-Relay bleibt unangetastet (kein `deploy_vm`); er bekommt den Stack beim nächsten natürlichen Redeploy — oder gezielt, falls wir das Mesh-Experiment vervollständigen wollen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)