### PR TITLE
chore(relay-button): bump rootfs to 8255cdf1 (first-entry delivery fix)

### DIFF
--- a/static/rootfs-manifest.json
+++ b/static/rootfs-manifest.json
@@ -49,9 +49,9 @@
     }
   ],
   "rootfsSizeMiB": 20480,
-  "createdAt": "2026-07-22T13:36:10.702Z",
+  "createdAt": "2026-07-22T15:32:00.742Z",
   "notes": "The OrbitDB relay image prebakes Node.js, production dependencies, and Caddy into the qcow2, delays first relay start until Aleph host port mappings are known, exposes a temporary setup endpoint on port 80, and uses Caddy on port 443 to front both HTTPS helper routes and secure libp2p WSS transport for the configured proxy hostname.",
-  "rootfsSourceSizeBytes": 663091200,
-  "rootfsCid": "QmRQUfeeCN4mbvwv6hxNGvvfAnTGUntEUNtrwdDWMLCyDi",
-  "rootfsItemHash": "be595acb45bc7bb1b3fea005e6ad679c7caea8e4fb1d8d432e01571374853174"
+  "rootfsSourceSizeBytes": 663376896,
+  "rootfsCid": "Qmcyk4sCN8bojdgARmntxswZHzTNyRXZwRmYJyfZrygRCj",
+  "rootfsItemHash": "8255cdf1364e404267cdc0e2e1328cdd0ba6579decbb62d03f8d634f538c5072"
 }


### PR DESCRIPTION
Manifest-Bump auf das Image aus orbitdb-relay `22cb5b3` (`republishHeadsToSubscribers`, [orbitdb-relay#16](https://github.com/NiKrause/orbitdb-relay/pull/16)).

| Feld | alt | neu |
|---|---|---|
| `rootfsItemHash` | `be595acb…` | **`8255cdf1…`** |
| `rootfsCid` | `QmRQUfeeCN…` | **`Qmcyk4sCN8…`** |

**Warum:** Button-provisionierte Relays sollen den First-Entry-Delivery-Fix mitbringen — der Relay re-annonciert frisch gesyncte Heads per `sync.add()`, sodass ein Reader, der vor der Entry-Ankunft ausgetauscht hat, es trotzdem bekommt. Genau der Fall, der den collab01-Cross-Network-Test vorher 4/4 rot machte. Nur die 4 Image-Felder ändern sich; per Guard auf Aleph verifiziert. Der laufende Produktions-Relay hat den Fix bereits (in-place); dieses Image ist für frische/Button-Deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)