### PR TITLE
chore(relay-button): bump rootfs to 06837f9b (gossipsub peer-scoring fix)

### DIFF
--- a/static/rootfs-manifest.json
+++ b/static/rootfs-manifest.json
@@ -49,9 +49,9 @@
     }
   ],
   "rootfsSizeMiB": 20480,
-  "createdAt": "2026-07-22T15:32:00.742Z",
+  "createdAt": "2026-07-22T17:18:05.104Z",
   "notes": "The OrbitDB relay image prebakes Node.js, production dependencies, and Caddy into the qcow2, delays first relay start until Aleph host port mappings are known, exposes a temporary setup endpoint on port 80, and uses Caddy on port 443 to front both HTTPS helper routes and secure libp2p WSS transport for the configured proxy hostname.",
-  "rootfsSourceSizeBytes": 663376896,
-  "rootfsCid": "Qmcyk4sCN8bojdgARmntxswZHzTNyRXZwRmYJyfZrygRCj",
-  "rootfsItemHash": "8255cdf1364e404267cdc0e2e1328cdd0ba6579decbb62d03f8d634f538c5072"
+  "rootfsSourceSizeBytes": 662323712,
+  "rootfsCid": "QmSz2t7Q32pwnqvVDWTFQ34rswFWoeZimSS8Yz9AQVad7N",
+  "rootfsItemHash": "06837f9b397e4b59b6fd0c89fe31649199b70d39c6a100f34f5a57d2dab5ef74"
 }


### PR DESCRIPTION
Manifest-Bump auf das Image aus orbitdb-relay `45e1b4b` ([#17](https://github.com/NiKrause/orbitdb-relay/pull/17)) — deaktiviert gossipsubs IP-Colocation- und Behaviour-Penalty, sodass Browser (alle via Caddy als 127.0.0.1) unter Last nicht mehr negativ gescored und aus dem Mesh gedrängt werden.

| Feld | alt | neu |
|---|---|---|
| `rootfsItemHash` | `8255cdf1…` | **`06837f9b…`** |
| `rootfsCid` | `Qmcyk4sCN8…` | **`QmSz2t7Q32…`** |

Button-provisionierte Relays tragen damit **alle** heutigen Fixes im Image: Scoring, First-Entry-Delivery, DHT-off, AutoTLS. Nur die 4 Image-Felder, per Guard auf Aleph verifiziert. Der Produktions-Relay läuft bereits mit allen Fixes (in-place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)