### PR TITLE
Rootfs 0e28e180 (registration publish retry) + E2E failover budget

### DIFF
--- a/.github/workflows/relay-button-e2e.yml
+++ b/.github/workflows/relay-button-e2e.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble
-    timeout-minutes: 40
+    timeout-minutes: 60
     env:
       RELAY_BUTTON_E2E_PRIVATE_KEY: ${{ secrets.RELAY_BUTTON_E2E_PRIVATE_KEY }}
       RELAY_BUTTON_E2E_SSH_PUBLIC_KEY: ${{ vars.RELAY_BUTTON_E2E_SSH_PUBLIC_KEY }}

--- a/e2e/relay-button-provisioning.spec.js
+++ b/e2e/relay-button-provisioning.spec.js
@@ -22,7 +22,10 @@ const PRIVATE_KEY = process.env.RELAY_BUTTON_E2E_PRIVATE_KEY?.trim();
 const SSH_PUBLIC_KEY = process.env.RELAY_BUTTON_E2E_SSH_PUBLIC_KEY?.trim();
 const APP_URL = process.env.RELAY_BUTTON_E2E_APP_URL ?? 'http://localhost:4173';
 const OUTPUT_DIR = 'test-results/relay-button';
-const PROVISION_TIMEOUT = 20 * 60_000;
+// Must fit several CRN failover attempts: a single failed attempt costs
+// 7-13 min (VM boot + config-ack wait + HTTPS activation wait) before the
+// controller moves to the next CRN, and two flaky CRNs in a row are routine.
+const PROVISION_TIMEOUT = 35 * 60_000;
 const REGISTRATION_TIMEOUT = 15 * 60_000;
 const RELAY_READINESS_TIMEOUT = 10 * 60_000;
 const RELAY_DIAL_ATTEMPT_TIMEOUT = 20_000;
@@ -103,7 +106,7 @@ relayTest.describe('Sponsor Relay button', () => {
 		!SSH_PUBLIC_KEY,
 		'RELAY_BUTTON_E2E_SSH_PUBLIC_KEY is required to provision an Aleph relay.'
 	);
-	relayTest.setTimeout(30 * 60_000);
+	relayTest.setTimeout(50 * 60_000);
 
 	relayTest(
 		'provisions a relay and replicates the main database between two browsers',

--- a/static/rootfs-manifest.json
+++ b/static/rootfs-manifest.json
@@ -49,10 +49,10 @@
     }
   ],
   "rootfsSizeMiB": 20480,
-  "createdAt": "2026-07-24T07:32:41.194Z",
+  "createdAt": "2026-07-24T09:08:45.961Z",
   "notes": "The OrbitDB relay image prebakes Node.js, production dependencies, and Caddy into the qcow2, delays first relay start until Aleph host port mappings are known, exposes a temporary setup endpoint on port 80, and uses Caddy on port 443 to front both HTTPS helper routes and secure libp2p WSS transport for the configured proxy hostname.",
   "supportsBootstrapConfigAggregate": true,
-  "rootfsSourceSizeBytes": 662989824,
-  "rootfsCid": "QmYUGWUte3BuxZuFEs3GqsWY37oT27oofimMuYGApfqeaR",
-  "rootfsItemHash": "4f817b95c7da2ee4494505f2c1f425b865304f033505aa896e08be7356fcf57d"
+  "rootfsSourceSizeBytes": 662892544,
+  "rootfsCid": "QmcL6iFeCZuaj1JnPxGE1xCC9rZJQKZ88TA6Co22xLiHWW",
+  "rootfsItemHash": "a8d91161dca730886a43ca0511dee2113a8007ec5855b9150fef70c954280405"
 }

--- a/static/rootfs-manifest.json
+++ b/static/rootfs-manifest.json
@@ -49,10 +49,10 @@
     }
   ],
   "rootfsSizeMiB": 20480,
-  "createdAt": "2026-07-24T09:08:45.961Z",
+  "createdAt": "2026-07-24T09:57:36.186Z",
   "notes": "The OrbitDB relay image prebakes Node.js, production dependencies, and Caddy into the qcow2, delays first relay start until Aleph host port mappings are known, exposes a temporary setup endpoint on port 80, and uses Caddy on port 443 to front both HTTPS helper routes and secure libp2p WSS transport for the configured proxy hostname.",
   "supportsBootstrapConfigAggregate": true,
-  "rootfsSourceSizeBytes": 662892544,
-  "rootfsCid": "QmcL6iFeCZuaj1JnPxGE1xCC9rZJQKZ88TA6Co22xLiHWW",
-  "rootfsItemHash": "a8d91161dca730886a43ca0511dee2113a8007ec5855b9150fef70c954280405"
+  "rootfsSourceSizeBytes": 663541760,
+  "rootfsCid": "QmeWpLGMX59SNLW5PALLbwhYGHPRcqs5q7k8Jgk9cMBmNb",
+  "rootfsItemHash": "0e28e180d5f0007693d5ae38f4c437bafb6e356db1b71b7656b36366fabe26f1"
 }


### PR DESCRIPTION
Green full E2E: [run 30086098729](https://github.com/NiKrause/simple-todo/actions/runs/30086098729) — and it exercised the whole machinery: CRN 1 flaked, failover moved on, CRN 2 delivered a dialable relay, full A↔B replication, mixed-content guard 0 insecure requests, 0 SSL errors, 25 min.

- **Rootfs `0e28e180…`** (relay-button [#74](https://github.com/NiKrause/relay-button/pull/74) + [#75](https://github.com/NiKrause/relay-button/pull/75)): symmetric cert verification for both browser paths (2n6 + AutoTLS, correct port) and the registration publish retry loop — publishes only once a secure browser-dialable address exists, closing the 16-min dead zone that produced `Relay did not advertise an authenticated browser-dialable address`.
- **E2E budget**: provision 20→35 min, test 30→50 min, job 40→60 min — a single failed CRN attempt costs 7-13 min, so the old budget died 15 s into attempt 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)