### PR TITLE
fix: scope bootstrap discovery to the production registrationId

### DIFF
--- a/scripts/resolve-aleph-bootstrap.mjs
+++ b/scripts/resolve-aleph-bootstrap.mjs
@@ -1,7 +1,7 @@
 import { appendFile } from 'node:fs/promises';
 import { noise } from '@chainsafe/libp2p-noise';
 import { yamux } from '@chainsafe/libp2p-yamux';
-import { discoverAlephBootstrapMultiaddrs } from '@le-space/aleph-bootstrap';
+import { discoverScopedBootstrapMultiaddrs } from '../src/lib/aleph-bootstrap-discovery.js';
 import { ping } from '@libp2p/ping';
 import { webRTCDirect } from '@libp2p/webrtc';
 import { webSockets } from '@libp2p/websockets';
@@ -83,10 +83,16 @@ const fallback = process.env.RELAY_BOOTSTRAP_FALLBACK?.trim() || '';
 // browsers cannot form a shared circuit with (a `uc-go-peer` relay leaves two
 // orbitdb browsers stuck at `candidates: 0`).
 const profile = process.env.RELAY_BOOTSTRAP_PROFILE?.trim() || 'orbitdb-relay';
+// Bake only the production registration into the site bundle: ephemeral E2E
+// relays (`relay:<profile>:simple-todo-e2e-*`) may be alive during a build,
+// pass the ping probe, and then become permanent dial noise for every
+// visitor once their VM is erased (issue #84).
+const registrationId =
+	process.env.RELAY_BOOTSTRAP_REGISTRATION_ID?.trim() || 'relay:orbitdb-relay:orbitdb-relay';
 
 let resolution = resolveBootstrapMultiaddrs({ override, fallback });
 if (resolution.source !== 'override') {
-	const discovered = await discoverAlephBootstrapMultiaddrs({ browserDialableOnly: true, profile });
+	const discovered = await discoverScopedBootstrapMultiaddrs({ profile, registrationId });
 	resolution = resolveBootstrapMultiaddrs({ override, discovered, fallback });
 }
 

--- a/src/lib/ManualConnectForm.svelte
+++ b/src/lib/ManualConnectForm.svelte
@@ -67,16 +67,20 @@
 				return;
 			}
 
-			const { discoverAlephBootstrapMultiaddrs } = await import('@le-space/aleph-bootstrap');
-			const discovered = await discoverAlephBootstrapMultiaddrs({
-				browserDialableOnly: true,
+			const { discoverScopedBootstrapMultiaddrs } = await import(
+				'./aleph-bootstrap-discovery.js'
+			);
+			const discovered = await discoverScopedBootstrapMultiaddrs({
 				// Only surface relays of our own implementation. The Aleph channel is
 				// shared with other relay profiles (e.g. universal-connectivity's
 				// `uc-go-peer`) that an orbitdb browser cannot replicate through.
 				profile: import.meta.env.VITE_RELAY_BOOTSTRAP_PROFILE || 'orbitdb-relay',
-				// Relay guests refresh every six hours. One day tolerates a missed refresh
-				// without keeping dead temporary registrations visible for a week.
-				maxAgeMs: 24 * 60 * 60 * 1000
+				// Scope to the production registration: ephemeral E2E relays register
+				// as `simple-todo-e2e-*` and their orphaned records otherwise flood
+				// the probe wave with dead addresses (issue #84).
+				registrationId:
+					import.meta.env.VITE_RELAY_BOOTSTRAP_REGISTRATION_ID ||
+					'relay:orbitdb-relay:orbitdb-relay'
 			});
 			const candidates = selectValidBrowserBootstrapMultiaddrs(discovered);
 			discoveredAddressCount = candidates.length;

--- a/src/lib/aleph-bootstrap-discovery.js
+++ b/src/lib/aleph-bootstrap-discovery.js
@@ -1,0 +1,40 @@
+import {
+	fetchAlephBootstrapPosts,
+	selectCurrentRelayBootstrapPosts,
+	filterRelayBootstrapPostsByProfile
+} from '@le-space/aleph-bootstrap';
+
+// The relay registrations live on a public Aleph channel: anyone with an ETH
+// key can post there, and registrations of erased VMs are orphaned forever
+// (guests self-publish with generated keys since relay-button #66, so no
+// remaining key can FORGET them). Discovery therefore scopes hard before any
+// dial probe runs (issue #84):
+//  - registrationId: only the app's own production registration — ephemeral
+//    E2E relays register as `relay:<profile>:simple-todo-e2e-*` and polluted
+//    the candidate list until the browser's probe wave exhausted its stream
+//    budget and dropped the healthy relay along with the corpses.
+//  - maxAgeMs: orphans stop refreshing (live relays republish every 6 h), so
+//    anything older than ~2 cadences is dead weight even when the
+//    registrationId matches.
+const DEFAULT_REGISTRATION_ID = 'relay:orbitdb-relay:orbitdb-relay';
+const DEFAULT_MAX_AGE_MS = 13 * 60 * 60 * 1000;
+
+export async function discoverScopedBootstrapMultiaddrs({
+	profile = 'orbitdb-relay',
+	registrationId = DEFAULT_REGISTRATION_ID,
+	maxAgeMs = DEFAULT_MAX_AGE_MS,
+	pagination = 100
+} = {}) {
+	const posts = await fetchAlephBootstrapPosts({ pagination });
+	const current = selectCurrentRelayBootstrapPosts(posts, { maxAgeMs });
+	const profiled = filterRelayBootstrapPostsByProfile(current, profile);
+	const scoped = registrationId
+		? profiled.filter((post) => post.content?.registrationId === registrationId)
+		: profiled;
+	const addresses = scoped.flatMap((post) => {
+		const content = post.content;
+		if (!content) return [];
+		return content.browserMultiaddrs?.length ? content.browserMultiaddrs : (content.multiaddrs ?? []);
+	});
+	return [...new Set(addresses)];
+}


### PR DESCRIPTION
Fixes #84 — implements direction (1) from the issue: discovery (runtime **and** build-time snapshot) filters by `registrationId` in addition to `profile`, plus a 13 h staleness cut. Orphaned `simple-todo-e2e-*` registrations no longer reach the probe wave. Verified live: candidate list 24 → 6 (production only), resolver bakes 2 dialable 2n6 addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)