### PR TITLE
fix: scope bootstrap discovery to production registrationId [collab01 mirror]

### DIFF
--- a/scripts/resolve-aleph-bootstrap.mjs
+++ b/scripts/resolve-aleph-bootstrap.mjs
@@ -1,7 +1,7 @@
 import { appendFile } from 'node:fs/promises';
 import { noise } from '@chainsafe/libp2p-noise';
 import { yamux } from '@chainsafe/libp2p-yamux';
-import { discoverAlephBootstrapMultiaddrs } from '@le-space/aleph-bootstrap';
+import { discoverScopedBootstrapMultiaddrs } from '../src/lib/aleph-bootstrap-discovery.js';
 import { ping } from '@libp2p/ping';
 import { webRTCDirect } from '@libp2p/webrtc';
 import { webSockets } from '@libp2p/websockets';
@@ -77,17 +77,22 @@ async function verifyBootstrapMultiaddrs(addresses) {
 
 const override = process.env.RELAY_BOOTSTRAP_OVERRIDE?.trim() || '';
 const fallback = process.env.RELAY_BOOTSTRAP_FALLBACK?.trim() || '';
-
 // Multiple relay implementations register in the same Aleph channel
 // (`orbitdb-relay` for simple-todo, `uc-go-peer` for universal-connectivity).
 // Scope discovery to our own profile so the build never bakes in a relay the
 // browsers cannot form a shared circuit with (a `uc-go-peer` relay leaves two
 // orbitdb browsers stuck at `candidates: 0`).
 const profile = process.env.RELAY_BOOTSTRAP_PROFILE?.trim() || 'orbitdb-relay';
+// Bake only the production registration into the site bundle: ephemeral E2E
+// relays (`relay:<profile>:simple-todo-e2e-*`) may be alive during a build,
+// pass the ping probe, and then become permanent dial noise for every
+// visitor once their VM is erased (issue #84).
+const registrationId =
+	process.env.RELAY_BOOTSTRAP_REGISTRATION_ID?.trim() || 'relay:orbitdb-relay:orbitdb-relay';
 
 let resolution = resolveBootstrapMultiaddrs({ override, fallback });
 if (resolution.source !== 'override') {
-	const discovered = await discoverAlephBootstrapMultiaddrs({ browserDialableOnly: true, profile });
+	const discovered = await discoverScopedBootstrapMultiaddrs({ profile, registrationId });
 	resolution = resolveBootstrapMultiaddrs({ override, discovered, fallback });
 }
 

--- a/src/lib/ManualConnectForm.svelte
+++ b/src/lib/ManualConnectForm.svelte
@@ -55,13 +55,19 @@
 				return;
 			}
 
-			const { discoverAlephBootstrapMultiaddrs } = await import('@le-space/aleph-bootstrap');
-			// Scope discovery to our relay profile — the Aleph channel is shared
-			// with other profiles (e.g. universal-connectivity's `uc-go-peer`),
-			// whose relays leave two orbitdb browsers stuck at `candidates: 0`.
-			const discovered = await discoverAlephBootstrapMultiaddrs({
-				browserDialableOnly: true,
-				profile: import.meta.env.VITE_RELAY_BOOTSTRAP_PROFILE || 'orbitdb-relay'
+			const { discoverScopedBootstrapMultiaddrs } = await import(
+				'./aleph-bootstrap-discovery.js'
+			);
+			// Scope discovery to our relay profile AND our production registration.
+			// The Aleph channel is shared with other profiles (e.g.
+			// universal-connectivity's `uc-go-peer`), and orphaned registrations
+			// of erased E2E relays (`simple-todo-e2e-*`) otherwise flood the probe
+			// wave with dead addresses (issue #84).
+			const discovered = await discoverScopedBootstrapMultiaddrs({
+				profile: import.meta.env.VITE_RELAY_BOOTSTRAP_PROFILE || 'orbitdb-relay',
+				registrationId:
+					import.meta.env.VITE_RELAY_BOOTSTRAP_REGISTRATION_ID ||
+					'relay:orbitdb-relay:orbitdb-relay'
 			});
 			const candidates = selectValidBrowserBootstrapMultiaddrs(discovered);
 			discoveredAddressCount = candidates.length;

--- a/src/lib/aleph-bootstrap-discovery.js
+++ b/src/lib/aleph-bootstrap-discovery.js
@@ -1,0 +1,40 @@
+import {
+	fetchAlephBootstrapPosts,
+	selectCurrentRelayBootstrapPosts,
+	filterRelayBootstrapPostsByProfile
+} from '@le-space/aleph-bootstrap';
+
+// The relay registrations live on a public Aleph channel: anyone with an ETH
+// key can post there, and registrations of erased VMs are orphaned forever
+// (guests self-publish with generated keys since relay-button #66, so no
+// remaining key can FORGET them). Discovery therefore scopes hard before any
+// dial probe runs (issue #84):
+//  - registrationId: only the app's own production registration — ephemeral
+//    E2E relays register as `relay:<profile>:simple-todo-e2e-*` and polluted
+//    the candidate list until the browser's probe wave exhausted its stream
+//    budget and dropped the healthy relay along with the corpses.
+//  - maxAgeMs: orphans stop refreshing (live relays republish every 6 h), so
+//    anything older than ~2 cadences is dead weight even when the
+//    registrationId matches.
+const DEFAULT_REGISTRATION_ID = 'relay:orbitdb-relay:orbitdb-relay';
+const DEFAULT_MAX_AGE_MS = 13 * 60 * 60 * 1000;
+
+export async function discoverScopedBootstrapMultiaddrs({
+	profile = 'orbitdb-relay',
+	registrationId = DEFAULT_REGISTRATION_ID,
+	maxAgeMs = DEFAULT_MAX_AGE_MS,
+	pagination = 100
+} = {}) {
+	const posts = await fetchAlephBootstrapPosts({ pagination });
+	const current = selectCurrentRelayBootstrapPosts(posts, { maxAgeMs });
+	const profiled = filterRelayBootstrapPostsByProfile(current, profile);
+	const scoped = registrationId
+		? profiled.filter((post) => post.content?.registrationId === registrationId)
+		: profiled;
+	const addresses = scoped.flatMap((post) => {
+		const content = post.content;
+		if (!content) return [];
+		return content.browserMultiaddrs?.length ? content.browserMultiaddrs : (content.multiaddrs ?? []);
+	});
+	return [...new Set(addresses)];
+}


### PR DESCRIPTION
collab01 mirror of #85 (fixes #84): registrationId + staleness scoping for runtime discovery and the baked snapshot. Surgical port — no cross-chapter merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)