### PR TITLE
Adopt @libp2p/gossipsub 16.1.0 (graft-on-subscribe) + relay image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
 			"orbitdb-relay>@orbitdb/core": "4.0.0",
 			"react": "19.2.6",
 			"react-dom": "19.2.6",
-			"@ipshipyard/node-datachannel": "npm:node-datachannel@0.29.0"
+			"@ipshipyard/node-datachannel": "npm:node-datachannel@0.29.0",
+			"@libp2p/gossipsub": "16.1.0"
 		},
 		"peerDependencyRules": {
 			"allowedVersions": {
@@ -92,7 +93,7 @@
 		"@libp2p/circuit-relay-v2": "^4.2.9",
 		"@libp2p/crypto": "^5.1.21",
 		"@libp2p/dcutr": "^3.0.24",
-		"@libp2p/gossipsub": "^16.0.5",
+		"@libp2p/gossipsub": "^16.1.0",
 		"@libp2p/identify": "^4.1.10",
 		"@libp2p/ping": "^3.1.9",
 		"@libp2p/pubsub-peer-discovery": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   react: 19.2.6
   react-dom: 19.2.6
   '@ipshipyard/node-datachannel': npm:node-datachannel@0.29.0
+  '@libp2p/gossipsub': 16.1.0
 
 importers:
 
@@ -23,13 +24,13 @@ importers:
         version: 8.0.1
       '@helia/bitswap':
         specifier: ^4.0.6
-        version: 4.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 4.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@helia/http':
         specifier: ^4.0.5
         version: 4.0.5
       '@helia/libp2p':
         specifier: ^1.0.6
-        version: 1.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 1.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@ipld/dag-cbor':
         specifier: ^10.0.1
         version: 10.0.1
@@ -61,8 +62,8 @@ importers:
         specifier: ^3.0.24
         version: 3.0.24
       '@libp2p/gossipsub':
-        specifier: ^16.0.5
-        version: 16.0.5
+        specifier: 16.1.0
+        version: 16.1.0
       '@libp2p/identify':
         specifier: ^4.1.10
         version: 4.1.10
@@ -77,7 +78,7 @@ importers:
         version: 7.3.0
       '@libp2p/webrtc':
         specifier: ^6.0.27
-        version: 6.0.27(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 6.0.27(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@libp2p/websockets':
         specifier: ^10.1.17
         version: 10.1.17
@@ -92,7 +93,7 @@ importers:
         version: 6.0.3
       helia:
         specifier: ^7.1.0
-        version: 7.1.0(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.1.0(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       interface-blockstore:
         specifier: ^7.0.1
         version: 7.0.1
@@ -123,7 +124,7 @@ importers:
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.5
-        version: 1.3.1(eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2))
+        version: 1.3.1(eslint@9.32.0(jiti@2.5.1))
       '@eslint/js':
         specifier: ^9.18.0
         version: 9.32.0
@@ -132,7 +133,7 @@ importers:
         version: 0.7.0(typescript@5.9.2)
       '@le-space/node':
         specifier: 0.7.0
-        version: 0.7.0(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.2)
+        version: 0.7.0(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(typescript@5.9.2)
       '@le-space/playwright':
         specifier: 0.7.0
         version: 0.7.0(@playwright/test@1.61.1)(typescript@5.9.2)
@@ -141,13 +142,13 @@ importers:
         version: 1.61.1
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
-        version: 3.0.8(@sveltejs/kit@2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))
+        version: 3.0.8(@sveltejs/kit@2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: ^2.22.0
-        version: 2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
+        version: 2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0
-        version: 6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
+        version: 6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
       '@tailwindcss/forms':
         specifier: ^0.5.9
         version: 0.5.10(tailwindcss@4.1.11)
@@ -162,13 +163,13 @@ importers:
         version: 3.2.4(playwright@1.61.1)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)
       eslint:
         specifier: ^9.18.0
-        version: 9.32.0(jiti@2.5.1)(supports-color@10.2.2)
+        version: 9.32.0(jiti@2.5.1)
       eslint-config-prettier:
         specifier: ^10.0.1
-        version: 10.1.8(eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-svelte:
         specifier: ^3.0.0
-        version: 3.11.0(eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2))(svelte@5.37.2)
+        version: 3.11.0(eslint@9.32.0(jiti@2.5.1))(svelte@5.37.2)
       globals:
         specifier: ^16.0.0
         version: 16.3.0
@@ -177,7 +178,7 @@ importers:
         version: 3.3.2
       orbitdb-relay:
         specifier: ^0.9.7
-        version: 0.9.7(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(rollup@4.46.2)(supports-color@10.2.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.9.7(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
       playwright:
         specifier: 1.61.1
         version: 1.61.1
@@ -210,13 +211,13 @@ importers:
         version: 7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
       vitest:
         specifier: ^3.2.3
-        version: 3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(supports-color@10.2.2)(terser@5.49.0)(yaml@2.9.0)
+        version: 3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
       vitest-browser-svelte:
         specifier: ^0.1.0
         version: 0.1.0(@vitest/browser@3.2.4)(svelte@5.37.2)(vitest@3.2.4)
       wait-on:
         specifier: ^8.0.4
-        version: 8.0.4(debug@4.4.3(supports-color@10.2.2))
+        version: 8.0.4
 
 packages:
 
@@ -1060,8 +1061,8 @@ packages:
   '@libp2p/dcutr@3.0.24':
     resolution: {integrity: sha512-cCAVxFH+NVqRxSUsA4Ha/e+LMjnvwSQHKIHUjj9QleSJMqCENZkF9gZnA3DDqmb2xxK34PdInrGveURlV5RmsQ==}
 
-  '@libp2p/gossipsub@16.0.5':
-    resolution: {integrity: sha512-ta1kVSOebVZPKrgzbj3XLv/Rw7ivpXvxu3moQo97P7G4GTDbqL+Jio80H3lj99NzvXlu457JN6byeBAtmqLkbQ==}
+  '@libp2p/gossipsub@16.1.0':
+    resolution: {integrity: sha512-r+4nIE7JIHiJxSMm75kcPrsYFgbU6Q7fdz2RdxiM5KEC0wrkj7veQ+GXuqpnJ0h7czJG+vwujy+TpxNuiuN9/w==}
     engines: {npm: '>=8.7.0'}
 
   '@libp2p/http-fetch@2.2.2':
@@ -1090,6 +1091,9 @@ packages:
 
   '@libp2p/interface-internal@2.3.19':
     resolution: {integrity: sha512-v335EB0i5CaNF+0SqT01CTBp0VyjJizpy46KprcshFFjX16UQ8+/QzoTZqmot9WiAmAzwR0b87oKmlAE9cpxzQ==}
+
+  '@libp2p/interface-internal@3.1.10':
+    resolution: {integrity: sha512-JABQ6iHSKsYT25I9UzY7LNrmqiJscgjgVTfKBuFBA58Q9i0zO+sqHzNi2zGl8qaDbxNpDwrwuHS6CCBW+VLa3A==}
 
   '@libp2p/interface-internal@3.1.8':
     resolution: {integrity: sha512-MJ/DR+H8xdhRIdDSh/BzHIxgmBQ9HoVoBwISOb582IDd5ZXF6xrtaVzC6Vn4n/OMwUDPfda3OD/aMNAlygtoEw==}
@@ -1121,6 +1125,9 @@ packages:
   '@libp2p/logger@6.2.10':
     resolution: {integrity: sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==}
 
+  '@libp2p/logger@6.2.11':
+    resolution: {integrity: sha512-zZ4m2EKyyRY2G8GAzmG/ZJm4CIqmaJucl5X7zTmGs1SXlb4Ayj4aP1vsaP/cVWadf/RuPWjgmIJP+Y/sZoE7Rg==}
+
   '@libp2p/logger@6.2.9':
     resolution: {integrity: sha512-hjuF81KSt9dWNPJZcdJ4SHEuygMLHrPZVTGNzCWu+2jxpJqOHWy9CJS8llLH7pgbDtlq4jJ4uuqihCR5Gjo4gA==}
 
@@ -1145,11 +1152,17 @@ packages:
   '@libp2p/peer-collections@7.0.24':
     resolution: {integrity: sha512-RBwYVj0gtO1VMjxjjlAzHqztB9fJyL/U3G5vJrpHdXWtGlXs5ZzpkW65nGXkBExKpoGRAV59WIkOOeRDiX9c2Q==}
 
+  '@libp2p/peer-collections@7.0.25':
+    resolution: {integrity: sha512-34XvvkfVf7jR9J3b924f75d7bbF4deGnCx4ws+wixVysRigpI+uvsqptreEuDcsXuRPA1AIZYshCZEKeujz1Zw==}
+
   '@libp2p/peer-id@5.1.9':
     resolution: {integrity: sha512-cVDp7lX187Epmi/zr0Qq2RsEMmueswP9eIxYSFoMcHL/qcvRFhsxOfUGB8361E26s2WJvC9sXZ0oJS9XVueJhQ==}
 
   '@libp2p/peer-id@6.0.12':
     resolution: {integrity: sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==}
+
+  '@libp2p/peer-id@6.0.13':
+    resolution: {integrity: sha512-A3sP3QUjunp7Wo5aGOkRsuYtGJZbLD4KPlHKObMam1fUCx+gHKnfyKeaWMQLkjeaUNETz9R6llquWyi41QzkLg==}
 
   '@libp2p/peer-record@8.0.35':
     resolution: {integrity: sha512-0818zvjKbucq5XBnusG8oSWxJ992rVry/2qlfcn/nyK/uDrZ12tjDYHNMCoOWTNeFvFUVkMg9pRkvXvTNp6Yiw==}
@@ -1198,6 +1211,9 @@ packages:
 
   '@libp2p/utils@7.3.0':
     resolution: {integrity: sha512-7mDQQVutmz6LsrehO9W12RI0Hwnx/zQzqlsj1DB0/2vHf8As/4jEntoEM8ko6RAOaDQ7Y5OrJ2Fgd7O9gyVRkA==}
+
+  '@libp2p/utils@7.3.1':
+    resolution: {integrity: sha512-kIV7Nrtn8mMephggO+xFD75sIRH7birJyfhOlGnprRLKjE8Ots5rsSqTjlrjLhrJxhxO71F+UOSyVAkqxi+d4w==}
 
   '@libp2p/webrtc@5.2.24':
     resolution: {integrity: sha512-0Ne/GDR0FBnKQ/KpJDdQ0Ohii1jyhSCJvbKRxLISm8XItCuJtE1WA2awiWZddZwp2lPDPh9iQmFaYUvv8Zel2w==}
@@ -5273,20 +5289,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7(supports-color@10.2.2)':
+  '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5311,19 +5327,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -5346,79 +5362,79 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.28.2': {}
@@ -5431,7 +5447,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7(supports-color@10.2.2)':
+  '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -5439,7 +5455,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5720,21 +5736,21 @@ snapshots:
   '@esbuild/win32-x64@0.25.8':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2))':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.32.0(jiti@2.5.1))':
     dependencies:
-      eslint: 9.32.0(jiti@2.5.1)(supports-color@10.2.2)
+      eslint: 9.32.0(jiti@2.5.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.3.1(eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2))':
+  '@eslint/compat@1.3.1(eslint@9.32.0(jiti@2.5.1))':
     optionalDependencies:
-      eslint: 9.32.0(jiti@2.5.1)(supports-color@10.2.2)
+      eslint: 9.32.0(jiti@2.5.1)
 
-  '@eslint/config-array@0.21.0(supports-color@10.2.2)':
+  '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1(supports-color@10.2.2)
+      debug: 4.4.1
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5745,10 +5761,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1(supports-color@10.2.2)':
+  '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@10.2.2)
+      debug: 4.4.1
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -5800,10 +5816,10 @@ snapshots:
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.0
 
-  '@helia/bitswap@4.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@helia/bitswap@4.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))':
     dependencies:
       '@helia/interface': 7.1.0
-      '@helia/libp2p': 1.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      '@helia/libp2p': 1.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@helia/utils': 3.0.4
       '@libp2p/interface': 3.2.5
       '@libp2p/logger': 6.2.10
@@ -5931,14 +5947,14 @@ snapshots:
       multiformats: 14.0.4
       progress-events: 1.1.0
 
-  '@helia/libp2p@1.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@helia/libp2p@1.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))':
     dependencies:
       '@chainsafe/libp2p-noise': 17.0.0
       '@chainsafe/libp2p-yamux': 8.0.1
       '@helia/delegated-routing-client': 1.0.5
       '@helia/delegated-routing-v1-http-api-client': 9.0.0
       '@helia/interface': 7.1.0
-      '@ipshipyard/libp2p-auto-tls': 2.0.2(supports-color@10.2.2)
+      '@ipshipyard/libp2p-auto-tls': 2.0.2
       '@libp2p/autonat': 3.0.24
       '@libp2p/bootstrap': 12.0.27
       '@libp2p/circuit-relay-v2': 4.2.9
@@ -5956,7 +5972,7 @@ snapshots:
       '@libp2p/tcp': 11.0.24
       '@libp2p/tls': 3.1.6
       '@libp2p/upnp-nat': 4.0.24
-      '@libp2p/webrtc': 6.0.27(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      '@libp2p/webrtc': 6.0.27(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@libp2p/websockets': 10.1.17
       '@multiformats/dns': 1.0.15
       '@multiformats/multiaddr': 13.0.3
@@ -6000,7 +6016,7 @@ snapshots:
       uint8arraylist: 3.0.2
       uint8arrays: 6.1.1
 
-  '@helia/unixfs@7.2.1(supports-color@10.2.2)':
+  '@helia/unixfs@7.2.1':
     dependencies:
       '@helia/interface': 6.2.1
       '@ipld/dag-pb': 4.1.7
@@ -6011,7 +6027,7 @@ snapshots:
       interface-blockstore: 6.0.2
       ipfs-unixfs: 12.0.2
       ipfs-unixfs-exporter: 15.0.4
-      ipfs-unixfs-importer: 16.1.5(supports-color@10.2.2)
+      ipfs-unixfs-importer: 16.1.5
       it-all: 3.0.11
       it-first: 3.0.11
       it-glob: 3.0.6
@@ -6026,7 +6042,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@helia/unixfs@8.0.4(supports-color@10.2.2)':
+  '@helia/unixfs@8.0.4':
     dependencies:
       '@helia/interface': 7.1.0
       '@ipld/dag-pb': 4.1.7
@@ -6037,7 +6053,7 @@ snapshots:
       interface-blockstore: 7.0.1
       ipfs-unixfs: 13.0.0
       ipfs-unixfs-exporter: 16.0.2
-      ipfs-unixfs-importer: 17.0.1(supports-color@10.2.2)
+      ipfs-unixfs-importer: 17.0.1
       it-all: 3.0.11
       it-first: 3.0.11
       it-glob: 3.0.6
@@ -6172,7 +6188,7 @@ snapshots:
       sanitize-filename: 1.6.4
       uint8arrays: 6.1.1
 
-  '@ipshipyard/libp2p-auto-tls@1.0.0(supports-color@10.2.2)':
+  '@ipshipyard/libp2p-auto-tls@1.0.0':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@libp2p/crypto': 5.1.21
@@ -6184,7 +6200,7 @@ snapshots:
       '@multiformats/multiaddr': 12.5.1
       '@multiformats/multiaddr-matcher': 1.8.0
       '@peculiar/x509': 1.14.3
-      acme-client: 5.4.0(supports-color@10.2.2)
+      acme-client: 5.4.0
       any-signal: 4.2.0
       delay: 6.0.0
       interface-datastore: 8.3.2
@@ -6193,7 +6209,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ipshipyard/libp2p-auto-tls@2.0.2(supports-color@10.2.2)':
+  '@ipshipyard/libp2p-auto-tls@2.0.2':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@libp2p/crypto': 5.1.21
@@ -6205,7 +6221,7 @@ snapshots:
       '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       '@peculiar/x509': 2.0.0
-      acme-client: 5.4.0(supports-color@10.2.2)
+      acme-client: 5.4.0
       any-signal: 4.2.0
       delay: 7.0.0
       interface-datastore: 10.0.1
@@ -6255,12 +6271,12 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.12
 
-  '@jest/transform@29.7.0(supports-color@10.2.2)':
+  '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 6.1.1(supports-color@10.2.2)
+      babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -6367,14 +6383,14 @@ snapshots:
     dependencies:
       iso-base: '@le-space/iso-base@4.3.0'
 
-  '@le-space/node@0.7.0(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.2)':
+  '@le-space/node@0.7.0(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(typescript@5.9.2)':
     dependencies:
       '@chainsafe/libp2p-noise': 16.1.5
       '@chainsafe/libp2p-quic': 1.1.8
       '@chainsafe/libp2p-yamux': 7.0.4
       '@helia/block-brokers': 5.2.4
       '@helia/routers': 5.1.1
-      '@helia/unixfs': 7.2.1(supports-color@10.2.2)
+      '@helia/unixfs': 7.2.1
       '@helia/utils': 2.5.2
       '@ipld/car': 5.4.6
       '@le-space/core': 0.7.0(typescript@5.9.2)
@@ -6394,7 +6410,7 @@ snapshots:
       '@libp2p/peer-id': 5.1.9
       '@libp2p/ping': 2.0.37
       '@libp2p/tcp': 10.1.19
-      '@libp2p/webrtc': 5.2.24(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      '@libp2p/webrtc': 5.2.24(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@libp2p/websockets': 9.2.19
       '@multiformats/multiaddr': 12.5.1
       '@ucanto/core': '@le-space/ucanto-core@10.5.1'
@@ -6402,7 +6418,7 @@ snapshots:
       blockstore-core: 6.1.3
       datastore-core: 11.0.4
       ethers: 6.17.0
-      ipfs-unixfs-importer: 16.1.5(supports-color@10.2.2)
+      ipfs-unixfs-importer: 16.1.5
       libp2p: 2.10.0
       libp2p-helia: libp2p@3.3.6
       multiformats: 14.0.4
@@ -6601,19 +6617,19 @@ snapshots:
       protons-runtime: 7.0.0
       uint8arraylist: 3.0.2
 
-  '@libp2p/gossipsub@16.0.5':
+  '@libp2p/gossipsub@16.1.0':
     dependencies:
       '@libp2p/crypto': 5.1.21
       '@libp2p/interface': 3.2.5
-      '@libp2p/interface-internal': 3.1.9
-      '@libp2p/peer-id': 6.0.12
-      '@libp2p/utils': 7.3.0
+      '@libp2p/interface-internal': 3.1.10
+      '@libp2p/peer-id': 6.0.13
+      '@libp2p/utils': 7.3.1
       '@multiformats/multiaddr': 13.0.3
       denque: 2.1.0
       it-length-prefixed: 11.0.1
       it-pipe: 3.0.1
-      it-pushable: 3.2.3
-      multiformats: 14.0.3
+      it-pushable: 3.2.4
+      multiformats: 14.0.4
       protons-runtime: 7.0.0
       uint8arraylist: 3.0.2
       uint8arrays: 6.1.1
@@ -6731,6 +6747,13 @@ snapshots:
       '@libp2p/interface': 2.11.0
       '@libp2p/peer-collections': 6.0.35
       '@multiformats/multiaddr': 12.5.1
+      progress-events: 1.1.0
+
+  '@libp2p/interface-internal@3.1.10':
+    dependencies:
+      '@libp2p/interface': 3.2.5
+      '@libp2p/peer-collections': 7.0.25
+      '@multiformats/multiaddr': 13.0.3
       progress-events: 1.1.0
 
   '@libp2p/interface-internal@3.1.8':
@@ -6874,6 +6897,14 @@ snapshots:
       multiformats: 14.0.4
       weald: 1.1.3
 
+  '@libp2p/logger@6.2.11':
+    dependencies:
+      '@libp2p/interface': 3.2.5
+      '@multiformats/multiaddr': 13.0.3
+      interface-datastore: 10.0.1
+      multiformats: 14.0.4
+      weald: 1.1.3
+
   '@libp2p/logger@6.2.9':
     dependencies:
       '@libp2p/interface': 3.2.5
@@ -6944,6 +6975,13 @@ snapshots:
       '@libp2p/utils': 7.3.0
       multiformats: 14.0.4
 
+  '@libp2p/peer-collections@7.0.25':
+    dependencies:
+      '@libp2p/interface': 3.2.5
+      '@libp2p/peer-id': 6.0.13
+      '@libp2p/utils': 7.3.1
+      multiformats: 14.0.4
+
   '@libp2p/peer-id@5.1.9':
     dependencies:
       '@libp2p/crypto': 5.1.21
@@ -6952,6 +6990,13 @@ snapshots:
       uint8arrays: 5.1.0
 
   '@libp2p/peer-id@6.0.12':
+    dependencies:
+      '@libp2p/crypto': 5.1.21
+      '@libp2p/interface': 3.2.5
+      multiformats: 14.0.4
+      uint8arrays: 6.1.1
+
+  '@libp2p/peer-id@6.0.13':
     dependencies:
       '@libp2p/crypto': 5.1.21
       '@libp2p/interface': 3.2.5
@@ -7178,7 +7223,35 @@ snapshots:
       uint8arraylist: 3.0.2
       uint8arrays: 6.1.1
 
-  '@libp2p/webrtc@5.2.24(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@libp2p/utils@7.3.1':
+    dependencies:
+      '@chainsafe/is-ip': 2.1.0
+      '@chainsafe/netmask': 2.0.0
+      '@libp2p/interface': 3.2.5
+      '@libp2p/logger': 6.2.11
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      '@sindresorhus/fnv1a': 3.1.0
+      any-signal: 4.2.0
+      cborg: 5.1.7
+      delay: 7.0.0
+      is-loopback-addr: 2.0.2
+      it-length-prefixed: 11.0.1
+      it-pipe: 3.0.1
+      it-pushable: 3.2.4
+      it-stream-types: 2.0.4
+      main-event: 1.0.4
+      netmask: 2.1.1
+      p-defer: 4.0.1
+      p-event: 7.1.0
+      progress-events: 1.1.0
+      protons-runtime: 7.0.0
+      race-signal: 2.0.0
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
+  '@libp2p/webrtc@5.2.24(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@chainsafe/libp2p-noise': 16.1.5
@@ -7210,7 +7283,7 @@ snapshots:
       protons-runtime: 5.6.0
       race-event: 1.6.1
       race-signal: 1.1.3
-      react-native-webrtc: 124.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      react-native-webrtc: 124.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       uint8-varint: 2.0.5
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.0
@@ -7218,7 +7291,7 @@ snapshots:
       - react-native
       - supports-color
 
-  '@libp2p/webrtc@6.0.27(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@libp2p/webrtc@6.0.27(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@chainsafe/libp2p-noise': 17.0.0
@@ -7248,7 +7321,7 @@ snapshots:
       progress-events: 1.1.0
       protons-runtime: 7.0.0
       race-signal: 2.0.0
-      react-native-webrtc: 124.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      react-native-webrtc: 124.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       reflect-metadata: 0.2.2
       uint8-varint: 3.0.0
       uint8arraylist: 3.0.2
@@ -7570,23 +7643,23 @@ snapshots:
 
   '@react-native/assets-registry@0.80.2': {}
 
-  '@react-native/codegen@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@react-native/codegen@0.80.2(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       glob: 7.2.3
       hermes-parser: 0.28.1
       invariant: 2.2.4
       nullthrows: 1.1.1
       yargs: 17.7.3
 
-  '@react-native/community-cli-plugin@0.80.2(supports-color@10.2.2)':
+  '@react-native/community-cli-plugin@0.80.2':
     dependencies:
-      '@react-native/dev-middleware': 0.80.2(supports-color@10.2.2)
+      '@react-native/dev-middleware': 0.80.2
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       invariant: 2.2.4
-      metro: 0.82.5(supports-color@10.2.2)
-      metro-config: 0.82.5(supports-color@10.2.2)
+      metro: 0.82.5
+      metro-config: 0.82.5
       metro-core: 0.82.5
       semver: 7.8.5
     transitivePeerDependencies:
@@ -7596,18 +7669,18 @@ snapshots:
 
   '@react-native/debugger-frontend@0.80.2': {}
 
-  '@react-native/dev-middleware@0.80.2(supports-color@10.2.2)':
+  '@react-native/dev-middleware@0.80.2':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.80.2
-      chrome-launcher: 0.15.2(supports-color@10.2.2)
-      chromium-edge-launcher: 0.2.0(supports-color@10.2.2)
-      connect: 3.7.0(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
+      chrome-launcher: 0.15.2
+      chromium-edge-launcher: 0.2.0
+      connect: 3.7.0
+      debug: 4.4.3
       invariant: 2.2.4
       nullthrows: 1.1.1
       open: 7.4.2
-      serve-static: 1.16.3(supports-color@10.2.2)
+      serve-static: 1.16.3
       ws: 6.2.6
     transitivePeerDependencies:
       - bufferutil
@@ -7620,12 +7693,12 @@ snapshots:
 
   '@react-native/normalize-colors@0.80.2': {}
 
-  '@react-native/virtualized-lists@0.80.2(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(react@19.2.6)':
+  '@react-native/virtualized-lists@0.80.2(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(react@19.2.6)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.6
-      react-native: 0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2)
+      react-native: 0.80.2(@babel/core@7.29.7)(react@19.2.6)
 
   '@rollup/plugin-inject@5.0.5(rollup@4.46.2)':
     dependencies:
@@ -7759,15 +7832,15 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))':
+  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
-      '@sveltejs/kit': 2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
 
-  '@sveltejs/kit@2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))':
+  '@sveltejs/kit@2.27.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -7782,19 +7855,19 @@ snapshots:
       svelte: 5.37.2
       vite: 7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.0(@sveltejs/vite-plugin-svelte@6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
-      debug: 4.4.1(supports-color@10.2.2)
+      '@sveltejs/vite-plugin-svelte': 6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
+      debug: 4.4.1
       svelte: 5.37.2
       vite: 7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.0(@sveltejs/vite-plugin-svelte@6.1.0(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(supports-color@10.2.2)(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
-      debug: 4.4.1(supports-color@10.2.2)
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(svelte@5.37.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
+      debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
@@ -8002,7 +8075,7 @@ snapshots:
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(supports-color@10.2.2)(terser@5.49.0)(yaml@2.9.0)
+      vitest: 3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.61.1
@@ -8078,12 +8151,12 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acme-client@5.4.0(supports-color@10.2.2):
+  acme-client@5.4.0:
     dependencies:
       '@peculiar/x509': 1.13.0
       asn1js: 3.0.10
-      axios: 1.11.0(debug@4.4.3(supports-color@10.2.2))
-      debug: 4.4.3(supports-color@10.2.2)
+      axios: 1.11.0(debug@4.4.3)
+      debug: 4.4.3
       node-forge: 1.3.1
     transitivePeerDependencies:
       - supports-color
@@ -8184,9 +8257,9 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.11.0(debug@4.4.3(supports-color@10.2.2)):
+  axios@1.11.0(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3(supports-color@10.2.2))
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -8194,25 +8267,25 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2):
+  babel-jest@29.7.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@jest/transform': 29.7.0(supports-color@10.2.2)
+      '@babel/core': 7.29.7
+      '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1(supports-color@10.2.2)
-      babel-preset-jest: 29.6.3(@babel/core@7.29.7(supports-color@10.2.2))
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.29.7)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-istanbul@6.1.1(supports-color@10.2.2):
+  babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
-      istanbul-lib-instrument: 5.2.1(supports-color@10.2.2)
+      istanbul-lib-instrument: 5.2.1
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -8228,30 +8301,30 @@ snapshots:
     dependencies:
       hermes-parser: 0.28.1
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7(supports-color@10.2.2)):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.7
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
 
-  babel-preset-jest@29.6.3(@babel/core@7.29.7(supports-color@10.2.2)):
+  babel-preset-jest@29.6.3(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@10.2.2))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
   balanced-match@1.0.2: {}
 
@@ -8507,21 +8580,21 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chrome-launcher@0.15.2(supports-color@10.2.2):
+  chrome-launcher@0.15.2:
     dependencies:
       '@types/node': 26.1.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
-      lighthouse-logger: 1.4.2(supports-color@10.2.2)
+      lighthouse-logger: 1.4.2
     transitivePeerDependencies:
       - supports-color
 
-  chromium-edge-launcher@0.2.0(supports-color@10.2.2):
+  chromium-edge-launcher@0.2.0:
     dependencies:
       '@types/node': 26.1.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
-      lighthouse-logger: 1.4.2(supports-color@10.2.2)
+      lighthouse-logger: 1.4.2
       mkdirp: 1.0.4
       rimraf: 3.0.2
     transitivePeerDependencies:
@@ -8585,10 +8658,10 @@ snapshots:
       semver: 7.8.5
       uint8array-extras: 1.5.0
 
-  connect@3.7.0(supports-color@10.2.2):
+  connect@3.7.0:
     dependencies:
-      debug: 2.6.9(supports-color@10.2.2)
-      finalhandler: 1.1.2(supports-color@10.2.2)
+      debug: 2.6.9
+      finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -8733,29 +8806,21 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  debug@2.6.9(supports-color@10.2.2):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 10.2.2
 
-  debug@4.3.4(supports-color@10.2.2):
+  debug@4.3.4:
     dependencies:
       ms: 2.1.2
-    optionalDependencies:
-      supports-color: 10.2.2
 
-  debug@4.4.1(supports-color@10.2.2):
+  debug@4.4.1:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
 
-  debug@4.4.3(supports-color@10.2.2):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
 
   decompress-response@6.0.0:
     dependencies:
@@ -8960,15 +9025,15 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2)):
+  eslint-config-prettier@10.1.8(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.32.0(jiti@2.5.1)(supports-color@10.2.2)
+      eslint: 9.32.0(jiti@2.5.1)
 
-  eslint-plugin-svelte@3.11.0(eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2))(svelte@5.37.2):
+  eslint-plugin-svelte@3.11.0(eslint@9.32.0(jiti@2.5.1))(svelte@5.37.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
       '@jridgewell/sourcemap-codec': 1.5.4
-      eslint: 9.32.0(jiti@2.5.1)(supports-color@10.2.2)
+      eslint: 9.32.0(jiti@2.5.1)
       esutils: 2.0.3
       globals: 16.3.0
       known-css-properties: 0.37.0
@@ -8991,14 +9056,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2):
+  eslint@9.32.0(jiti@2.5.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.0(supports-color@10.2.2)
+      '@eslint/config-array': 0.21.0
       '@eslint/config-helpers': 0.3.0
       '@eslint/core': 0.15.1
-      '@eslint/eslintrc': 3.3.1(supports-color@10.2.2)
+      '@eslint/eslintrc': 3.3.1
       '@eslint/js': 9.32.0
       '@eslint/plugin-kit': 0.3.4
       '@humanfs/node': 0.16.6
@@ -9009,7 +9074,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@10.2.2)
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -9144,9 +9209,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.1.2(supports-color@10.2.2):
+  finalhandler@1.1.2:
     dependencies:
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -9175,9 +9240,9 @@ snapshots:
 
   flow-enums-runtime@0.0.6: {}
 
-  follow-redirects@1.15.11(debug@4.4.3(supports-color@10.2.2)):
+  follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:
@@ -9305,12 +9370,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  helia@7.1.0(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2):
+  helia@7.1.0(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6)):
     dependencies:
-      '@helia/bitswap': 4.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      '@helia/bitswap': 4.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@helia/http': 4.0.5
       '@helia/interface': 7.1.0
-      '@helia/libp2p': 1.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      '@helia/libp2p': 1.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@helia/utils': 3.0.4
       '@ipld/dag-cbor': 10.0.1
       '@ipld/dag-json': 11.0.0
@@ -9379,10 +9444,10 @@ snapshots:
 
   https-browserify@1.0.0: {}
 
-  https-proxy-agent@7.0.6(supports-color@10.2.2):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9495,7 +9560,7 @@ snapshots:
       p-queue: 9.3.1
       progress-events: 1.1.0
 
-  ipfs-unixfs-importer@16.1.5(supports-color@10.2.2):
+  ipfs-unixfs-importer@16.1.5:
     dependencies:
       '@ipld/dag-pb': 4.1.7
       '@multiformats/murmur3': 2.2.8
@@ -9510,14 +9575,14 @@ snapshots:
       it-parallel-batch: 3.0.11
       multiformats: 13.4.2
       progress-events: 1.1.0
-      rabin-wasm: 0.1.5(supports-color@10.2.2)
+      rabin-wasm: 0.1.5
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  ipfs-unixfs-importer@17.0.1(supports-color@10.2.2):
+  ipfs-unixfs-importer@17.0.1:
     dependencies:
       '@ipld/dag-pb': 4.1.7
       '@multiformats/murmur3': 2.2.8
@@ -9531,7 +9596,7 @@ snapshots:
       it-parallel-batch: 3.0.11
       multiformats: 14.0.4
       progress-events: 1.1.0
-      rabin-wasm: 0.1.5(supports-color@10.2.2)
+      rabin-wasm: 0.1.5
       uint8arraylist: 3.0.2
       uint8arrays: 6.1.1
     transitivePeerDependencies:
@@ -9673,9 +9738,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1(supports-color@10.2.2):
+  istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -10072,9 +10137,9 @@ snapshots:
       race-signal: 2.0.0
       uint8arrays: 6.1.1
 
-  lighthouse-logger@1.4.2(supports-color@10.2.2):
+  lighthouse-logger@1.4.2:
     dependencies:
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
       marky: 1.3.0
     transitivePeerDependencies:
       - supports-color
@@ -10198,9 +10263,9 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  metro-babel-transformer@0.82.5(supports-color@10.2.2):
+  metro-babel-transformer@0.82.5:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.29.1
       nullthrows: 1.1.1
@@ -10211,23 +10276,23 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
 
-  metro-cache@0.82.5(supports-color@10.2.2):
+  metro-cache@0.82.5:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       metro-core: 0.82.5
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.82.5(supports-color@10.2.2):
+  metro-config@0.82.5:
     dependencies:
-      connect: 3.7.0(supports-color@10.2.2)
+      connect: 3.7.0
       cosmiconfig: 5.2.1
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.82.5(supports-color@10.2.2)
-      metro-cache: 0.82.5(supports-color@10.2.2)
+      metro: 0.82.5
+      metro-cache: 0.82.5
       metro-core: 0.82.5
       metro-runtime: 0.82.5
     transitivePeerDependencies:
@@ -10241,9 +10306,9 @@ snapshots:
       lodash.throttle: 4.1.1
       metro-resolver: 0.82.5
 
-  metro-file-map@0.82.5(supports-color@10.2.2):
+  metro-file-map@0.82.5:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -10269,14 +10334,14 @@ snapshots:
       '@babel/runtime': 7.29.7
       flow-enums-runtime: 0.0.6
 
-  metro-source-map@0.82.5(supports-color@10.2.2):
+  metro-source-map@0.82.5:
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.7(supports-color@10.2.2)'
+      '@babel/traverse': 7.29.7
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.7'
       '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-symbolicate: 0.82.5(supports-color@10.2.2)
+      metro-symbolicate: 0.82.5
       nullthrows: 1.1.1
       ob1: 0.82.5
       source-map: 0.5.7
@@ -10284,62 +10349,62 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-symbolicate@0.82.5(supports-color@10.2.2):
+  metro-symbolicate@0.82.5:
     dependencies:
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-source-map: 0.82.5(supports-color@10.2.2)
+      metro-source-map: 0.82.5
       nullthrows: 1.1.1
       source-map: 0.5.7
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-plugins@0.82.5(supports-color@10.2.2):
+  metro-transform-plugins@0.82.5:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-worker@0.82.5(supports-color@10.2.2):
+  metro-transform-worker@0.82.5:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
-      metro: 0.82.5(supports-color@10.2.2)
-      metro-babel-transformer: 0.82.5(supports-color@10.2.2)
-      metro-cache: 0.82.5(supports-color@10.2.2)
+      metro: 0.82.5
+      metro-babel-transformer: 0.82.5
+      metro-cache: 0.82.5
       metro-cache-key: 0.82.5
       metro-minify-terser: 0.82.5
-      metro-source-map: 0.82.5(supports-color@10.2.2)
-      metro-transform-plugins: 0.82.5(supports-color@10.2.2)
+      metro-source-map: 0.82.5
+      metro-transform-plugins: 0.82.5
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  metro@0.82.5(supports-color@10.2.2):
+  metro@0.82.5:
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       accepts: 1.3.8
       chalk: 4.1.2
       ci-info: 2.0.0
-      connect: 3.7.0(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
+      connect: 3.7.0
+      debug: 4.4.3
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -10349,18 +10414,18 @@ snapshots:
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4
       lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.82.5(supports-color@10.2.2)
-      metro-cache: 0.82.5(supports-color@10.2.2)
+      metro-babel-transformer: 0.82.5
+      metro-cache: 0.82.5
       metro-cache-key: 0.82.5
-      metro-config: 0.82.5(supports-color@10.2.2)
+      metro-config: 0.82.5
       metro-core: 0.82.5
-      metro-file-map: 0.82.5(supports-color@10.2.2)
+      metro-file-map: 0.82.5
       metro-resolver: 0.82.5
       metro-runtime: 0.82.5
-      metro-source-map: 0.82.5(supports-color@10.2.2)
-      metro-symbolicate: 0.82.5(supports-color@10.2.2)
-      metro-transform-plugins: 0.82.5(supports-color@10.2.2)
-      metro-transform-worker: 0.82.5(supports-color@10.2.2)
+      metro-source-map: 0.82.5
+      metro-symbolicate: 0.82.5
+      metro-transform-plugins: 0.82.5
+      metro-transform-worker: 0.82.5
       mime-types: 2.1.35
       nullthrows: 1.1.1
       serialize-error: 2.1.0
@@ -10601,18 +10666,18 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  orbitdb-relay@0.9.7(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(rollup@4.46.2)(supports-color@10.2.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)):
+  orbitdb-relay@0.9.7(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       '@chainsafe/libp2p-noise': 17.0.0
       '@chainsafe/libp2p-quic': 2.0.1
       '@chainsafe/libp2p-yamux': 8.0.1
-      '@helia/bitswap': 4.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      '@helia/bitswap': 4.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@helia/http': 4.0.5
-      '@helia/libp2p': 1.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
-      '@helia/unixfs': 8.0.4(supports-color@10.2.2)
+      '@helia/libp2p': 1.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
+      '@helia/unixfs': 8.0.4
       '@ipld/dag-cbor': 10.0.1
       '@ipld/dag-json': 11.0.0
-      '@ipshipyard/libp2p-auto-tls': 1.0.0(supports-color@10.2.2)
+      '@ipshipyard/libp2p-auto-tls': 1.0.0
       '@le-space/orbitdb-access-controller-delegated-todo': 0.1.0(@le-space/orbitdb-identity-provider-webauthn-did@0.3.1(@orbitdb/core@4.0.0)(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)))(@orbitdb/core@4.0.0)
       '@le-space/orbitdb-identity-provider-webauthn-did': 0.3.1(@orbitdb/core@4.0.0)(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
       '@libp2p/autonat': 3.0.24
@@ -10620,7 +10685,7 @@ snapshots:
       '@libp2p/circuit-relay-v2': 4.2.9
       '@libp2p/crypto': 5.1.21
       '@libp2p/dcutr': 3.0.24
-      '@libp2p/gossipsub': 16.0.5
+      '@libp2p/gossipsub': 16.1.0
       '@libp2p/identify': 4.1.10
       '@libp2p/interface': 3.2.5
       '@libp2p/kad-dht': 16.3.4
@@ -10631,7 +10696,7 @@ snapshots:
       '@libp2p/pubsub-peer-discovery': 12.0.0
       '@libp2p/tcp': 11.0.23
       '@libp2p/utils': 7.3.0
-      '@libp2p/webrtc': 6.0.27(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      '@libp2p/webrtc': 6.0.27(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       '@libp2p/websockets': 10.1.17
       '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 1.8.0
@@ -10640,7 +10705,7 @@ snapshots:
       blockstore-level: 4.0.1
       datastore-level: 13.0.1
       dotenv: 16.6.1
-      helia: 7.1.0(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2)
+      helia: 7.1.0(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))
       interface-blockstore: 7.0.1
       interface-datastore: 10.0.1
       key-did-resolver: 4.0.0
@@ -10953,11 +11018,11 @@ snapshots:
     dependencies:
       inherits: 2.0.4
 
-  rabin-wasm@0.1.5(supports-color@10.2.2):
+  rabin-wasm@0.1.5:
     dependencies:
       '@assemblyscript/loader': 0.9.4
       bl: 5.1.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       minimist: 1.2.8
       node-fetch: 2.7.0
       readable-stream: 3.6.2
@@ -11010,29 +11075,29 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-native-webrtc@124.0.6(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(supports-color@10.2.2):
+  react-native-webrtc@124.0.6(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6)):
     dependencies:
       base64-js: 1.5.1
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4
       event-target-shim: 6.0.2
-      react-native: 0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2)
+      react-native: 0.80.2(@babel/core@7.29.7)(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
-  react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2):
+  react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.80.2
-      '@react-native/codegen': 0.80.2(@babel/core@7.29.7(supports-color@10.2.2))
-      '@react-native/community-cli-plugin': 0.80.2(supports-color@10.2.2)
+      '@react-native/codegen': 0.80.2(@babel/core@7.29.7)
+      '@react-native/community-cli-plugin': 0.80.2
       '@react-native/gradle-plugin': 0.80.2
       '@react-native/js-polyfills': 0.80.2
       '@react-native/normalize-colors': 0.80.2
-      '@react-native/virtualized-lists': 0.80.2(react-native@0.80.2(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.6)(supports-color@10.2.2))(react@19.2.6)
+      '@react-native/virtualized-lists': 0.80.2(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(react@19.2.6)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
-      babel-jest: 29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-jest: 29.7.0(@babel/core@7.29.7)
       babel-plugin-syntax-hermes-parser: 0.28.1
       base64-js: 1.5.1
       chalk: 4.1.2
@@ -11043,7 +11108,7 @@ snapshots:
       jest-environment-node: 29.7.0
       memoize-one: 5.2.1
       metro-runtime: 0.82.5
-      metro-source-map: 0.82.5(supports-color@10.2.2)
+      metro-source-map: 0.82.5
       nullthrows: 1.1.1
       pretty-format: 29.7.0
       promise: 8.3.0
@@ -11206,9 +11271,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@0.19.2(supports-color@10.2.2):
+  send@0.19.2:
     dependencies:
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -11226,12 +11291,12 @@ snapshots:
 
   serialize-error@2.1.0: {}
 
-  serve-static@1.16.3(supports-color@10.2.2):
+  serve-static@1.16.3:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2(supports-color@10.2.2)
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -11699,10 +11764,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@3.2.4(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(supports-color@10.2.2)(terser@5.49.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@10.2.2)
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
@@ -11752,9 +11817,9 @@ snapshots:
     dependencies:
       '@vitest/browser': 3.2.4(playwright@1.61.1)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))(vitest@3.2.4)
       svelte: 5.37.2
-      vitest: 3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(supports-color@10.2.2)(terser@5.49.0)(yaml@2.9.0)
+      vitest: 3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
 
-  vitest@3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(supports-color@10.2.2)(terser@5.49.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/node@26.1.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -11765,7 +11830,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.1
-      debug: 4.4.1(supports-color@10.2.2)
+      debug: 4.4.1
       expect-type: 1.2.2
       magic-string: 0.30.17
       pathe: 2.0.3
@@ -11777,7 +11842,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(supports-color@10.2.2)(terser@5.49.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1
@@ -11800,9 +11865,9 @@ snapshots:
 
   vm-browserify@1.1.2: {}
 
-  wait-on@8.0.4(debug@4.4.3(supports-color@10.2.2)):
+  wait-on@8.0.4:
     dependencies:
-      axios: 1.11.0(debug@4.4.3(supports-color@10.2.2))
+      axios: 1.11.0(debug@4.4.3)
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8

--- a/static/rootfs-manifest.json
+++ b/static/rootfs-manifest.json
@@ -49,10 +49,10 @@
     }
   ],
   "rootfsSizeMiB": 20480,
-  "createdAt": "2026-07-24T19:44:34.376Z",
+  "createdAt": "2026-07-26T13:09:20.320Z",
   "notes": "The OrbitDB relay image prebakes Node.js, production dependencies, and Caddy into the qcow2, delays first relay start until Aleph host port mappings are known, exposes a temporary setup endpoint on port 80, and uses Caddy on port 443 to front both HTTPS helper routes and secure libp2p WSS transport for the configured proxy hostname.",
   "supportsBootstrapConfigAggregate": true,
-  "rootfsSourceSizeBytes": 663825408,
-  "rootfsCid": "QmTi3y8ZANkaJ1zapVucMiG2AivqEcvgnw7zAY6HiD6kC7",
-  "rootfsItemHash": "2cc61c1d9f055fb8ef787610fd39392ea06040ffab37648ebaafa2380076969a"
+  "rootfsSourceSizeBytes": 663881728,
+  "rootfsCid": "QmdJjWcr3GxgWeMvxqSWQdZHZR4hy2pBvAXuyDi5iivEUn",
+  "rootfsItemHash": "ef7055381bd9e4fe279c2cd20dea08ede6045ac90d12d812bf397be9d3a2e86a"
 }


### PR DESCRIPTION
Browser @libp2p/gossipsub → 16.1.0 and rootfs manifest → the relay image built with 16.1.0. 16.1.0 is the first regular release containing [js-libp2p#3583](https://github.com/libp2p/js-libp2p/pull/3583) (graft-on-subscribe), which closes the publish-into-empty-mesh transport race. Measured: full E2E green with A↔B replication in ~4s (0 replication timeouts).

Note: this is the transport-race fix; it does NOT fix the separate OrbitDB Sync deadlock in [orbitdb#1255](https://github.com/orbitdb/orbitdb/issues/1255) (verified: the deterministic repro still reproduces under 16.1.0 — the relay's own heads-re-announce workaround remains required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)