### PR TITLE
fix(libp2p): deny plain-ws dials on https pages via the connection gater

### DIFF
--- a/src/lib/libp2p-config.js
+++ b/src/lib/libp2p-config.js
@@ -46,6 +46,32 @@ const RELAY_BOOTSTRAP_ADDR = (isDevelopment ? RELAY_BOOTSTRAP_ADDR_DEV : RELAY_B
 console.log('RELAY_BOOTSTRAP_ADDR', RELAY_BOOTSTRAP_ADDR);
 
 /**
+ * True when dialing this multiaddr would open an insecure WebSocket from a
+ * page that the browser serves over HTTPS — which Chrome blocks as mixed
+ * content. A multiaddr counts as secure when it carries `/tls/` (covers both
+ * `/tls/ws` and the AutoTLS `/tls/sni/<host>/ws` form) or `/wss`.
+ *
+ * On an http:// origin (local dev, the Playwright E2E suite) mixed content
+ * does not apply, so plain `/ws` stays dialable there.
+ *
+ * @param {{ toString: () => string }} multiaddr
+ * @param {string} [pageProtocol] defaults to the current page protocol
+ * @returns {boolean}
+ */
+export function isInsecureWebSocketDial(
+	multiaddr,
+	pageProtocol = typeof location === 'undefined' ? '' : location.protocol
+) {
+	if (pageProtocol !== 'https:') return false;
+
+	const address = String(multiaddr).toLowerCase();
+	const isWebSocket = /\/wss?(\/|$)/.test(address);
+	if (!isWebSocket) return false;
+
+	return !address.includes('/tls/') && !/\/wss(\/|$)/.test(address);
+}
+
+/**
  * @param {unknown | null} [privateKey=null]
  * @returns {Promise<any>}
  */
@@ -100,7 +126,22 @@ export async function createLibp2pConfig(privateKey = null) {
 		],
 		connectionEncrypters: [noise()],
 		connectionGater: {
-			denyDialMultiaddr: () => false,
+			// Chrome blocks ws:// from an https:// page as mixed content, so a plain
+			// WebSocket dial from a deployed chapter can never succeed — it only burns
+			// a dial attempt and floods the console. These dials do not come from our
+			// bootstrap list (that only carries wss/2n6 addresses) but from peers
+			// discovered over pubsub/identify, which announce their internal ws ports.
+			//
+			// libp2p used to filter this inside the transport, but @libp2p/websockets
+			// removed the browser dial filter (9.1.1, libp2p/js-libp2p#2838) and then
+			// the ws filters entirely (9.2.1, #2983) — both explicitly "in favour of
+			// the connection gater", i.e. this hook. Ours stubbed every check to
+			// `() => false`, so nothing was gated at all.
+			//
+			// Gate on the page protocol instead of banning /ws outright: local dev and
+			// the E2E suite serve the app over http://localhost and dial a plain-ws
+			// relay, where mixed content does not apply.
+			denyDialMultiaddr: (multiaddr) => isInsecureWebSocketDial(multiaddr),
 			denyDialPeer: () => false,
 			denyInboundConnection: () => false,
 			denyOutboundConnection: () => false,

--- a/src/lib/libp2p-config.spec.js
+++ b/src/lib/libp2p-config.spec.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { isInsecureWebSocketDial } from './libp2p-config.js';
+
+const PEER = '/p2p/12D3KooWAX2ARgYnWjrAPHiM9hAXBvGUaQ9iK1PBNCV4FbMBRDVu';
+const HTTPS = 'https:';
+const HTTP = 'http:';
+
+describe('isInsecureWebSocketDial', () => {
+	it('denies plain ws dials on an https page (Chrome blocks them as mixed content)', () => {
+		// The relay's internal ws port, announced via identify/pubsub — this is
+		// the address family that filled the console with mixed-content errors.
+		expect(isInsecureWebSocketDial(`/ip4/172.16.11.2/tcp/9092/ws${PEER}`, HTTPS)).toBe(true);
+		expect(isInsecureWebSocketDial(`/ip6/2001:4ba0::1/tcp/9092/ws${PEER}`, HTTPS)).toBe(true);
+		expect(isInsecureWebSocketDial(`/ip4/62.141.40.252/tcp/53380/ws${PEER}`, HTTPS)).toBe(true);
+	});
+
+	it('allows secure websocket forms on an https page', () => {
+		// 2n6 proxy form
+		expect(
+			isInsecureWebSocketDial(`/dns4/present-spin-private-slot.2n6.me/tcp/443/tls/ws${PEER}`, HTTPS)
+		).toBe(false);
+		// AutoTLS SNI form — resolves to wss://<sni-host>:<port>
+		expect(
+			isInsecureWebSocketDial(
+				`/ip4/62.141.40.252/tcp/53380/tls/sni/62-141-40-252.libp2p.direct/ws${PEER}`,
+				HTTPS
+			)
+		).toBe(false);
+		// Legacy /wss form
+		expect(isInsecureWebSocketDial(`/dns4/example.com/tcp/4002/wss${PEER}`, HTTPS)).toBe(false);
+	});
+
+	it('leaves non-websocket transports untouched', () => {
+		expect(isInsecureWebSocketDial(`/ip4/1.2.3.4/udp/4001/webrtc-direct${PEER}`, HTTPS)).toBe(false);
+		expect(isInsecureWebSocketDial(`/ip4/1.2.3.4/tcp/4001${PEER}`, HTTPS)).toBe(false);
+		expect(isInsecureWebSocketDial(`/p2p-circuit${PEER}`, HTTPS)).toBe(false);
+	});
+
+	it('allows plain ws on an http page so local dev and the E2E suite keep working', () => {
+		expect(isInsecureWebSocketDial(`/ip4/127.0.0.1/tcp/49102/ws${PEER}`, HTTP)).toBe(false);
+		expect(isInsecureWebSocketDial(`/ip4/172.16.11.2/tcp/9092/ws${PEER}`, HTTP)).toBe(false);
+	});
+});


### PR DESCRIPTION
Deployed chapters logged dozens of `Mixed Content … insecure WebSocket endpoint ws://…` errors (see the console screenshot in the discussion). Chrome blocks those dials outright, so each is a guaranteed-failed connection attempt plus console noise.

**Where they came from** — not from our bootstrap list (that carries only `wss`/2n6 forms; verified against the live production registration) but from peers discovered over **pubsub/identify**, which announce their internal ws port (9092) and external plain-ws ports.

**Why there was no filter** — `@libp2p/websockets` removed the browser dial filter in 9.1.1 ([js-libp2p#2838](https://github.com/libp2p/js-libp2p/pull/2838)) and the ws filters entirely in 9.2.1 ([#2983](https://github.com/libp2p/js-libp2p/pull/2983)), both explicitly *“in favour of the connection gater”*. The `./filters` export is still declared in package.json but the file no longer ships. Our `connectionGater` existed but stubbed **every** hook to `() => false`, so nothing was gated at all.

**The fix** — `denyDialMultiaddr` now rejects websocket multiaddrs carrying neither `/tls/` (covers `/tls/ws` **and** the AutoTLS `/tls/sni/<host>/ws` form, both of which resolve to `wss://` — verified with `multiaddrToUri`) nor `/wss`. Gating happens in one place, so it covers every dial path: bootstrap, discovery auto-dial, relay reservations.

**Why protocol-aware and not a hard ban** — local dev and the Playwright suite serve the app over `http://localhost` and dial a plain-ws relay (`start-e2e-server.mjs` injects `ws://127.0.0.1`), where mixed content does not apply. A blanket `/ws` ban would break the E2E suite. 4 unit tests cover both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)