### PR TITLE
seo: de-index the acl01 chapter, canonicalise to the production app

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -41,8 +41,8 @@
 
 		<!-- Open Graph / Facebook / Telegram -->
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://simple-todo.le-space.de/" />
-		<meta property="og:title" content="Simple-Todo — A Local-First Peer-to-Peer TODO" />
+		<meta property="og:url" content="https://acl01.le-space.de/" />
+		<meta property="og:title" content="Simple-Todo — acl01 tutorial chapter" />
 		<meta
 			property="og:description"
 			content="A local-first peer-to-peer todo list. No servers, no accounts, no passwords — data you own. OrbitDB · IPFS · libp2p."
@@ -75,10 +75,16 @@
 		<meta name="msapplication-TileColor" content="#0B0E15" />
 			<meta name="msapplication-config" content="./browserconfig.xml" />
 
+		<!-- Tutorial chapter: this deployment shows an intentionally older state of
+		     the app, so it must not compete with the live product in search results.
+		     It stays crawlable (a disallowed page's noindex is never seen) but is
+		     de-indexed and points its canonical at the production app. -->
+		<link rel="canonical" href="https://simple-todo.le-space.de/" />
+
 		<!-- Technical Meta Tags -->
 		<meta name="format-detection" content="telephone=no" />
-		<meta name="robots" content="index, follow" />
-		<meta name="googlebot" content="index, follow" />
+		<meta name="robots" content="noindex, follow" />
+		<meta name="googlebot" content="noindex, follow" />
 
 		<!-- Schema.org markup -->
 		<meta itemprop="name" content="Simple-Todo — A Local-First Peer-to-Peer TODO" />


### PR DESCRIPTION
The chapter subdomains are deployed from near-identical sources to the live app, so search engines currently see several duplicates competing with the product — and a visitor can land on a chapter that deliberately shows an older state (collab01 has no passkeys, for example).

This chapter now carries:
- `<meta name="robots" content="noindex, follow">` (+ the same for `googlebot`)
- `<link rel="canonical" href="https://simple-todo.le-space.de/">`
- chapter-specific `og:url` / `og:title`, so a shared link previews honestly

**Deliberately NOT** added: a `Disallow:` in robots.txt — a page the crawler may not fetch is a page whose noindex and canonical it never sees.

**Why app.html and not `<svelte:head>`:** the app sets `ssr = false` (browser-only P2P), so component head tags never reach the prerendered HTML a crawler reads. Verified in the build output — the tags are only present via app.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)