### PR TITLE
seo: canonicalise every deployment to the production app

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -75,6 +75,11 @@
 		<meta name="msapplication-TileColor" content="#0B0E15" />
 			<meta name="msapplication-config" content="./browserconfig.xml" />
 
+		<!-- Consolidate ranking here: the tutorial chapters are deployed from
+		     near-identical sources to their own subdomains and canonicalise to this
+		     URL. -->
+		<link rel="canonical" href="https://simple-todo.le-space.de/" />
+
 		<!-- Technical Meta Tags -->
 		<meta name="format-detection" content="telephone=no" />
 		<meta name="robots" content="index, follow" />


### PR DESCRIPTION
Adds `<link rel="canonical" href="https://simple-todo.le-space.de/">` so the chapter subdomains (which are deployed from near-identical sources and now carry `noindex` + a canonical pointing here) consolidate onto the production app. main stays fully indexable.

**Why app.html and not `<svelte:head>`:** the app sets `ssr = false` (browser-only P2P), so component head tags never reach the prerendered HTML a crawler reads — verified in the build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)