### PR TITLE
fix(ci): let the janitor sweep simple-todo-e2e-* VMs and fail on unswept leaks

### DIFF
--- a/.github/workflows/aleph-playwright-janitor.yml
+++ b/.github/workflows/aleph-playwright-janitor.yml
@@ -16,5 +16,15 @@ jobs:
     with:
       repository_scope: NiKrause/simple-todo
       ttl_ms: 3600000
+      # The remote-replication E2E names its ephemeral relay VMs
+      # `simple-todo-e2e-<timestamp>`, which matches no
+      # `playwright-<repository>-` prefix. Two of them therefore ran 47 h and
+      # drained the E2E wallet from 846k to 35k credits while seven janitor runs
+      # reported success (#88).
+      extra_name_prefixes: simple-todo-e2e-
+      # This wallet only ever funds ephemeral E2E VMs — the production relay is
+      # funded separately — so anything past the TTL that the janitor cannot
+      # sweep is money burning and must turn the run red rather than warn.
+      fail_on_unswept: true
     secrets:
       ALEPH_PRIVATE_KEY: ${{ secrets.ALEPH_PLAYWRIGHT_PRIVATE_KEY || secrets.RELAY_BUTTON_E2E_PRIVATE_KEY }}


### PR DESCRIPTION
Closes #88. Consumes NiKrause/relay-button#85, already merged to `main`.

## What leaked

The janitor selected instances by the `playwright-<repository>-` prefix only. This repo's remote-replication E2E names its ephemeral relay VMs `simple-todo-e2e-<timestamp>`, which matches that prefix in no way, so every one of them was retained with `reason: 'name outside repository scope'` — forever.

Two orphans from 2026-07-26 ran for **47 hours** and drained the E2E wallet:

| | credits |
|---|---|
| 28.07. 11:59 (first `error 6`) | 1,063,095 |
| 28.07. 13:34 | 1,005,974 |
| 28.07. 18:42 | 846,231 |
| 30.07. 08:24 | **34,892** |

~811k credits burned at ~747k/day. They were finally deallocated by Aleph for lack of funds — **not** by cleanup. Meanwhile every Aleph-deploying job failed with scheduler `error 6`, which is simply "too little credit":

```json
{"account_credits":"1063095","min_runtime_days":1,"required_credits":"2054625.68"}
```

**Seven consecutive janitor runs reported `success` while this happened.** The last one's log contains exactly one relevant word: `skipped`. That is the part worth fixing beyond the prefix — a green janitor run carried no information about whether anything was actually running.

## Change

- `extra_name_prefixes: simple-todo-e2e-` — the VMs are now in scope and get erased + FORGOTten like the playwright runners, idempotently across runs so Aleph's FORGET lag (leak path 3 in the issue) resolves on a later pass.
- `fail_on_unswept: true` — an allocated, past-TTL instance that the janitor cannot sweep now turns the run **red**. Safe here specifically because this wallet only funds ephemeral E2E VMs; the production relay is funded from a separate account, which is why it survived this drain untouched.

This also covers leak paths 1 and 2 from the issue (INSTANCE broadcast landing after the test already failed; cleanup-FAILED runs) as a periodic safety net, rather than relying on the run's own exact-hash cleanup succeeding.

## TTL safety

TTL stays at 1 h against `timeout-minutes: 50` on the deploying job, so a live VM keeps a **≥10 minute margin** and cannot be swept mid-run. I checked the one remote-replication run that looked like 125 minutes: its job ran 11:49–11:50, and the span was a re-run against the same `createdAt`, not a long attempt.

## Verification

Upstream: 350 tests across 8 packages, lint clean, `pnpm build` typechecks. Two new selector tests — one replays this exact leak (`simple-todo-e2e-1785074478061` swept, a 30-min-old sibling retained as `within TTL`, an unrelated `orbitdb-relay-production` untouched), one asserts both 47 h orphans surface as `unswept` while a deallocated and a fresh out-of-scope instance do not.

Not verified against live Aleph — the script needs a repository secret I cannot read. The next scheduled run is the live check, and with **0 INSTANCEs currently allocated** it should be a clean no-op: 0 cleaned, 0 unswept, green.

## Still open, deliberately not in this PR

The wallet holds 34,892 credits and one E2E deploy needs 2,054,626 — the Aleph jobs stay red until it is topped up. This PR stops the next abandoned run from costing another ~800k; it cannot refund what was already spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)