### PR TITLE
fix(ci): repin the Playwright rootfs to the live STORE message

### DIFF
--- a/.github/workflows/remote-replication.yml
+++ b/.github/workflows/remote-replication.yml
@@ -84,7 +84,12 @@ jobs:
           api_hosts: https://api2.aleph.im,https://api.aleph.im
           name: simple-todo-${{ github.run_id }}-${{ github.run_attempt }}
           ssh_public_key: ${{ steps.credentials.outputs.ssh_public_key }}
-          rootfs_item_hash: 'c392fba3a392a9daa88a44620e0b0f4e5a260ccc3b56853eda8ed02009d8d4f1'
+          # Republished 2026-08-01 by relay-button's Playwright Runner RootFS
+          # workflow. The previous pin (c392fba3…) no longer resolves on either
+          # Aleph replica, so every INSTANCE was rejected with error 301
+          # (referenced message missing). Same image contents — the manifest
+          # reports playwrightVersion 1.61.1 either way.
+          rootfs_item_hash: 'b41c7fe9fe687a22f37f52b52d008a9a924280faec04591ecf47976038f065be'
           rootfs_version: playwright-1.61.1
           rootfs_size_mib: '20480'
           preferred_country_code: DE


### PR DESCRIPTION
## Why remote-replication is still red

Credits are no longer the problem. After the top-up and a janitor sweep, main's deploy got past the capacity gate and failed on a **different** error:

```
Deployment via Aleph scheduler was rejected: Aleph rejected this deployment
(error 301). Referenced message(s): c392fba3a392a9daa8…
```

`c392fba3…` is the pinned Playwright rootfs. It no longer exists:

| API | result |
|---|---|
| `https://api2.aleph.im` | `pagination_total: 0` |
| `https://api.aleph.im` | `pagination_total: 0` |

Gone from both replicas, so this is not replica lag.

## What happened to it

relay-button republished the image on **2026-08-01 11:00Z** ([run 30696633869](https://github.com/NiKrause/relay-button/actions/runs/30696633869)). That run's manifest:

```json
{
  "profile": "playwright-runner",
  "playwrightVersion": "1.61.1",
  "rootfsCid": "QmQz7uMWMniLFHYHxxxnAEUDKXVyn9B5byNotvKRWUQi2k",
  "rootfsItemHash": "b41c7fe9fe687a22f37f52b52d008a9a924280faec04591ecf47976038f065be"
}
```

Same `playwrightVersion` as the `rootfs_version: playwright-1.61.1` pin here, so this is a **repin, not a version bump** — no behaviour change expected in the guest.

The publishing run contains no `FORGET` and no mention of `c392fba3…`, so the old image was not deliberately retired. The likeliest explanation is that it fell out of retention while the E2E wallet was drained to 34,892 credits (see #88). **That is inference, not proof** — the deletion itself is not recorded anywhere I can read.

## Scope

Four branches pin the dead hash: `main`, `collab01`, `passkey01`, `acl01` (`collab02` has no `remote-replication.yml`). This PR fixes **main only**, so the repin can be proven green before touching the chapters — and per the standing rule, chapters get surgical per-branch commits, never a merge from main.

## Follow-up worth considering

Pinning an item hash that can silently disappear is fragile by construction. relay-button already maintains `packages/rootfs/reference/playwright-runner/latest.json` alongside a versioned manifest; resolving the hash from there at run time would turn this class of failure into a no-op. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)