### PR TITLE
fix(ci): give remote-replication real CRN failover, without a country pin

### DIFF
--- a/.github/workflows/remote-replication.yml
+++ b/.github/workflows/remote-replication.yml
@@ -92,7 +92,18 @@ jobs:
           rootfs_item_hash: 'b41c7fe9fe687a22f37f52b52d008a9a924280faec04591ecf47976038f065be'
           rootfs_version: playwright-1.61.1
           rootfs_size_mib: '20480'
-          preferred_country_code: DE
+          # Manual placement is what gives us CRN failover at all. Scheduler
+          # placement builds exactly one candidate ("attempting scheduler
+          # placement 1/1"), so a node that reserves the proxy slot and never
+          # boots the VM fails the whole run — and max_crn_attempts, which only
+          # shapes the manual candidate list, stays inert.
+          placement_strategy: manual
+          # Five is the size of the ranker's shuffled top pool; going past it
+          # lets failover walk into the ordered tail (6th, 7th, 8th).
+          max_crn_attempts: '8'
+          # No preferred_country_code on purpose: any preference switches the
+          # ranker to deterministic geo-first ordering and disables the top-5
+          # shuffle, sending every run at the same congested node.
           vcpus: '2'
           memory_mib: '4096'
           auto_configure: 'false'


### PR DESCRIPTION
Consumes NiKrause/relay-button#87 (merged).

## The failure this fixes

The previous run got past credits and past the rootfs repin, then died with the INSTANCE **accepted and paid for**:

```
[deploy] attempting scheduler placement 1/1
[deploy] Aleph processing 1/60: status=processed
[deploy] runtime 40/40: state=proxy-reserved-inactive host=- mapped_ports=0
[deploy] processed deployment never exposed usable runtime networking
[deploy] no candidate CRN succeeded
```

The assigned CRN reserved the proxy slot and never booted the VM. There was no second candidate to fall back to.

## Why there was no failover

`deploymentPlacementsForPlan` returns exactly **one** entry for scheduler placement (`packages/node/src/deploy-executor.ts:317`) — hence `1/1`. And `max_crn_attempts` only slices the *manual* candidate list (`:353`), so the `max_crn_attempts: 5` echoed in our logs was inert.

The retry across up to 5 CRNs was never lost — it lives in manual placement, which is why the go-peer profiles deploy fine against the *identical* runtime window (`runtime_attempts: 40`, `runtime_delay_ms: 5000`). relay-button#86 already defaulted the `aleph-playwright-runner` action to manual for exactly this reason; this repo calls `aleph-vm-deploy` **directly**, so it never picked that up and kept inheriting the `scheduler` default.

## Changes

| input | value | effect |
|---|---|---|
| `placement_strategy` | `manual` | real failover across ranked candidates |
| `max_crn_attempts` | `8` | walk past the shuffled top-5 into the ordered tail (6th, 7th, 8th) |
| `preferred_country_code` | **removed** | re-enables `shuffleTopPool` |

The last one is the subtle one. `rankCandidateCrns` shuffles its top-5 pool **only** on the no-country-preference path — with a preference it sorts deterministically geo-first, so every run starts at the same top-ranked node, which is usually the most congested. That is precisely the "reserved but never activated" symptom. relay-button#87 removed the baked-in `DE` at all four levels (both action inputs, the rootfs workflow input, and the env fallback in `deploy-plan.ts`), so simply dropping the line here now yields an empty preference rather than falling back to `DE`.

## Scope

`main` only, so the failover can be proven before the chapters follow. `collab01`, `passkey01` and `acl01` carry the same `preferred_country_code: DE` and the same scheduler default, and will need the same surgical change — never a merge from main.

## Not verified here

`remote-replication` is skipped on PRs, so this can only be proven by a run on `main` after merge. What I can state: the YAML parses to `placement_strategy: manual`, `max_crn_attempts: 8`, and no `preferred_country_code` key at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)