### PR TITLE
fix(ci): stop labelling the evidence region DE-preferred

### DIFF
--- a/.github/workflows/remote-replication.yml
+++ b/.github/workflows/remote-replication.yml
@@ -45,7 +45,10 @@ jobs:
       TESTINGBOT_KEY: ${{ secrets.TESTINGBOT_KEY }}
       TESTINGBOT_SECRET: ${{ secrets.TESTINGBOT_SECRET }}
       ALEPH_VM_PRIVATE_KEY: ${{ secrets.ALEPH_PLAYWRIGHT_PRIVATE_KEY || secrets.RELAY_BUTTON_E2E_PRIVATE_KEY }}
-      ALEPH_PLAYWRIGHT_REGION: DE-preferred
+      # Display label for the evidence summary only — it does not steer CRN
+      # selection. Kept truthful: placement is unpinned so the ranker can
+      # shuffle its top pool instead of always picking the same node.
+      ALEPH_PLAYWRIGHT_REGION: unpinned
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Cosmetic but load-bearing for diagnosis.

`ALEPH_PLAYWRIGHT_REGION` is a **display label only** — `e2e/remote/run-main.mjs:49` copies it into the evidence JSON and `:87` prints it in the job summary. It never influenced CRN selection.

After #117 removed the country pin it still read `DE-preferred`, so the evidence of the most recent run claims a preference that no longer exists. That is precisely the sort of stale label that sends the next investigation down the wrong path — it briefly did so for me.

Now reads `unpinned`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)