### PR TITLE
fix(ci): repin rootfs and give remote-replication CRN failover (acl01)

### DIFF
--- a/.github/workflows/remote-replication.yml
+++ b/.github/workflows/remote-replication.yml
@@ -45,7 +45,10 @@ jobs:
       TESTINGBOT_KEY: ${{ secrets.TESTINGBOT_KEY }}
       TESTINGBOT_SECRET: ${{ secrets.TESTINGBOT_SECRET }}
       ALEPH_VM_PRIVATE_KEY: ${{ secrets.ALEPH_PLAYWRIGHT_PRIVATE_KEY || secrets.RELAY_BUTTON_E2E_PRIVATE_KEY }}
-      ALEPH_PLAYWRIGHT_REGION: DE-preferred
+      # Display label for the evidence summary only — it does not steer CRN
+      # selection. Kept truthful: placement is unpinned so the ranker can
+      # shuffle its top pool instead of always picking the same node.
+      ALEPH_PLAYWRIGHT_REGION: unpinned
     steps:
       - uses: actions/checkout@v6
 
@@ -84,10 +87,26 @@ jobs:
           api_hosts: https://api2.aleph.im,https://api.aleph.im
           name: simple-todo-${{ github.run_id }}-${{ github.run_attempt }}
           ssh_public_key: ${{ steps.credentials.outputs.ssh_public_key }}
-          rootfs_item_hash: 'c392fba3a392a9daa88a44620e0b0f4e5a260ccc3b56853eda8ed02009d8d4f1'
+          # Republished 2026-08-01 by relay-button's Playwright Runner RootFS
+          # workflow. The previous pin (c392fba3…) no longer resolves on either
+          # Aleph replica, so every INSTANCE was rejected with error 301
+          # (referenced message missing). Same image contents — the manifest
+          # reports playwrightVersion 1.61.1 either way.
+          rootfs_item_hash: 'b41c7fe9fe687a22f37f52b52d008a9a924280faec04591ecf47976038f065be'
           rootfs_version: playwright-1.61.1
           rootfs_size_mib: '20480'
-          preferred_country_code: DE
+          # Manual placement is what gives us CRN failover at all. Scheduler
+          # placement builds exactly one candidate ("attempting scheduler
+          # placement 1/1"), so a node that reserves the proxy slot and never
+          # boots the VM fails the whole run — and max_crn_attempts, which only
+          # shapes the manual candidate list, stays inert.
+          placement_strategy: manual
+          # Five is the size of the ranker's shuffled top pool; going past it
+          # lets failover walk into the ordered tail (6th, 7th, 8th).
+          max_crn_attempts: '8'
+          # No preferred_country_code on purpose: any preference switches the
+          # ranker to deterministic geo-first ordering and disables the top-5
+          # shuffle, sending every run at the same congested node.
           vcpus: '2'
           memory_mib: '4096'
           auto_configure: 'false'


### PR DESCRIPTION
Ports the three deploy fixes proven green on `main` into `acl01`. **Chapter-local commit — no merge from main**, so the tutorial content stays at this chapter's level. Same one-file diff on all three chapters.

## Why this chapter is broken today

Its `remote-replication` would fail exactly as main did, for two independent reasons:

**1. The pinned rootfs no longer exists.** `c392fba3…` returns `pagination_total: 0` on *both* Aleph replicas, so every INSTANCE is rejected:

```
Aleph rejected this deployment (error 301). Referenced message(s): c392fba3a392a9daa8…
```

relay-button republished the image on 2026-08-01 as `b41c7fe9…`; its manifest reports the same `playwrightVersion: 1.61.1`, so this is a repin, not a version bump.

**2. No CRN failover.** Without `placement_strategy`, the action defaults to `scheduler`, which builds exactly one candidate (`attempting scheduler placement 1/1`). A node that reserves the proxy slot and never boots the VM therefore fails the whole run, with no second candidate. `max_crn_attempts` only shapes the *manual* list, so it was inert.

**And the country pin made it worse.** `rankCandidateCrns` shuffles its top-5 pool **only** on the no-country-preference path — with `preferred_country_code: DE` it sorted deterministically geo-first, sending every run at the same top-ranked, usually most congested node. Removing it re-enables `shuffleTopPool`; `max_crn_attempts: '8'` then lets failover walk past that pool into the ordered tail.

## Evidence from main

After these exact changes, main's `remote-replication` went green with bidirectional replication in about a second:

```
passed: True   stage: completed
replication: { aToBMs: 1026, bToAMs: 1282 }
CRN: Free To Link Skyblue5 | region: unpinned
```

`ALEPH_PLAYWRIGHT_REGION` is a display label consumed by `e2e/remote/run-main.mjs`; it never steered selection, and after dropping the pin it would have claimed something untrue, so it now reads `unpinned`.

## Not verified here

`remote-replication` is skipped on PRs, so this cannot be proven green from the PR itself — it needs a run on `acl01` after merge. What is verified: the file parses, the diff is one file (+22/−3), and the identical change is green on main.

Note that main additionally needed a credit top-up and a janitor sweep before it could deploy at all; that part is account state, not per-branch config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)