### PR TITLE
fix(e2e): fail the relay run when its Aleph VM survives cleanup

### DIFF
--- a/e2e/relay-button-provisioning.spec.js
+++ b/e2e/relay-button-provisioning.spec.js
@@ -160,10 +160,7 @@ relayTest.describe('Sponsor Relay button', () => {
 				}
 				const host = url.hostname;
 				const isLocal =
-					host === 'localhost' ||
-					host === '127.0.0.1' ||
-					host === '::1' ||
-					host === '[::1]';
+					host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
 				if (url.protocol === 'http:' && !isLocal) {
 					insecureGuestRequests.push(request.url());
 					progress(`[mixed-content-guard] insecure request: ${request.url()}`);
@@ -183,6 +180,8 @@ relayTest.describe('Sponsor Relay button', () => {
 			const agentA = new TodoBrowserAgent('relay-e2e-a', browser, APP_URL, REPLICATION_TIMEOUT);
 			const agentB = new TodoBrowserAgent('relay-e2e-b', browser, APP_URL, REPLICATION_TIMEOUT);
 			let testError = null;
+			/** Cleanup failures used to be swallowed — see the rethrow below. */
+			let cleanupError = null;
 
 			try {
 				progress(
@@ -284,9 +283,7 @@ relayTest.describe('Sponsor Relay button', () => {
 							`mixed-content console errors: ${JSON.stringify(mixedContentErrors.slice(0, 5))}.`
 					);
 				}
-				progress(
-					'PASSED: mixed-content guard (no insecure guest requests during deployment)'
-				);
+				progress('PASSED: mixed-content guard (no insecure guest requests during deployment)');
 			} catch (error) {
 				testError = error instanceof Error ? error : new Error(String(error));
 				evidence.error = testError.message;
@@ -320,18 +317,26 @@ relayTest.describe('Sponsor Relay button', () => {
 					} else {
 						pass('cleanup', results[0]?.verificationSummary ?? '');
 					}
-				} catch (cleanupError) {
-					const detail =
-						cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+				} catch (error) {
+					const detail = error instanceof Error ? error.message : String(error);
 					updateRelayEvidenceStep(evidence, 'cleanup', 'failed', detail);
 					progress(`cleanup FAILED: ${detail}`);
+					cleanupError = new Error(`Aleph VM ${instanceName} was left running: ${detail}`, {
+						cause: error instanceof Error ? error : undefined
+					});
 				}
 				evidence.finishedAt = new Date().toISOString();
 				await writeRelayEvidence(`${OUTPUT_DIR}/result.json`, evidence);
 				await deploymentContext.close();
 			}
 
+			// The provisioning failure is the more informative one, so it wins.
 			if (testError) throw testError;
+			// A surviving VM burns credits until the janitor's next sweep, up to
+			// ~7 h later at a 6 h cron against a 1 h TTL. Reporting the run green
+			// hid exactly that: four orphans from four "successful" runs drained
+			// the E2E wallet by ~811k credits before anyone looked (#88).
+			if (cleanupError) throw cleanupError;
 		}
 	);
 });


### PR DESCRIPTION
## The bug

`relay-button-provisioning.spec.js` drove cleanup explicitly, caught any failure, wrote it into the evidence — and then dropped it:

```js
} catch (cleanupError) {
  updateRelayEvidenceStep(evidence, 'cleanup', 'failed', detail);
  progress(`cleanup FAILED: ${detail}`);
}          // ← nothing rethrown
```

So a run that left a VM running still reported **success**. From today's run 30751650708:

```
14:19:13  cleanup: erasing and forgetting simple-todo-e2e-1785680116148…
14:19:15  Erased VM on CRN (moonlight5.zhuxx.site)     ← first attempt cleaned
14:21:05  Cleaning up failed attempt …                  ← a retry ran after
          → second INSTANCE at 14:21Z, never forgotten
cleanup FAILED: One or more Relay Button cleanups failed
→ workflow conclusion: success
```

That is leak path 1 from #88: the retry's INSTANCE is broadcast *after* cleanup collected its list, so it is never in scope.

## Why it is worth failing the run

Four "successful" runs between 08:45 and 09:36 today left four VMs behind. They burned the E2E wallet from 846,231 down to 34,892 credits — about **811k credits**, roughly 747k/day — and were finally deallocated by Aleph for lack of funds rather than by cleanup. Every Aleph-deploying job failed with scheduler `error 6` in the meantime.

The janitor now sweeps these (#113), but on a 6 h cron against a 1 h TTL a leak can burn for ~7 h before anything notices. A green run actively hides that; it is the same "green means nothing" pattern the janitor itself had.

## The change

`cleanupError` is captured and rethrown after the existing `testError` rethrow, so:

- provisioning failed → that error still surfaces (more informative)
- provisioning passed, cleanup failed → the run goes **red**, naming the surviving instance

The message carries the instance name (`Aleph VM simple-todo-e2e-… was left running: …`) and the original error as `cause`, so the leaked VM is identifiable straight from the failure line.

## Drive-by

Two prettier hunks unrelated to the logic. The file had already drifted: `prettier --check` fails on it at `main`, and **no workflow runs `pnpm lint`**, so nobody saw it. Flagging rather than hiding it — whether lint belongs in CI is a separate call.

## Scope

`main` only. `collab01`, `passkey01` and `acl01` carry the same swallow (`collab02` has no such spec) and need the same surgical change per chapter — never a merge from main. Happy to follow up once this is proven.

## Not verified

This cannot be proven green here: `Relay button E2E` needs `RELAY_BUTTON_E2E_PRIVATE_KEY` and provisions a real VM, and the wallet is currently 83,401 credits below the deploy threshold. Verified instead: the file parses, `eslint` is clean, `prettier --check` now passes, and the rethrow sits after the `testError` rethrow so the existing failure path is unchanged.

Refs #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)