### PR TITLE
fix(e2e): fail the relay run when its Aleph VM survives cleanup (collab01)

### DIFF
--- a/e2e/relay-button-provisioning.spec.js
+++ b/e2e/relay-button-provisioning.spec.js
@@ -188,10 +188,7 @@ relayTest.describe('Relay Button', () => {
 				}
 				const host = url.hostname;
 				const isLocal =
-					host === 'localhost' ||
-					host === '127.0.0.1' ||
-					host === '::1' ||
-					host === '[::1]';
+					host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
 				if (url.protocol === 'http:' && !isLocal) {
 					insecureGuestRequests.push(request.url());
 					progress(`[mixed-content-guard] insecure request: ${request.url()}`);
@@ -214,6 +211,8 @@ relayTest.describe('Relay Button', () => {
 			const agentA = new TodoBrowserAgent('relay-e2e-a', browser, APP_URL, REPLICATION_TIMEOUT);
 			const agentB = new TodoBrowserAgent('relay-e2e-b', browser, APP_URL, REPLICATION_TIMEOUT);
 			let testError = null;
+			/** Cleanup failures used to be swallowed — see the rethrow below. */
+			let cleanupError = null;
 
 			try {
 				progress(
@@ -346,9 +345,7 @@ relayTest.describe('Relay Button', () => {
 							`mixed-content console errors: ${JSON.stringify(mixedContentErrors.slice(0, 5))}.`
 					);
 				}
-				progress(
-					'PASSED: mixed-content guard (no insecure guest requests during deployment)'
-				);
+				progress('PASSED: mixed-content guard (no insecure guest requests during deployment)');
 			} catch (error) {
 				testError = error instanceof Error ? error : new Error(String(error));
 				evidence.error = testError.message;
@@ -379,18 +376,26 @@ relayTest.describe('Relay Button', () => {
 					} else {
 						pass('cleanup', results[0]?.verificationSummary ?? '');
 					}
-				} catch (cleanupError) {
-					const detail =
-						cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+				} catch (error) {
+					const detail = error instanceof Error ? error.message : String(error);
 					updateRelayEvidenceStep(evidence, 'cleanup', 'failed', detail);
 					progress(`cleanup FAILED: ${detail}`);
+					cleanupError = new Error(`Aleph VM ${instanceName} was left running: ${detail}`, {
+						cause: error instanceof Error ? error : undefined
+					});
 				}
 				evidence.finishedAt = new Date().toISOString();
 				await writeRelayEvidence(`${OUTPUT_DIR}/result.json`, evidence);
 				await deploymentContext.close();
 			}
 
+			// The provisioning failure is the more informative one, so it wins.
 			if (testError) throw testError;
+			// A surviving VM burns credits until the janitor's next sweep, up to
+			// ~7 h later at a 6 h cron against a 1 h TTL. Reporting the run green
+			// hid exactly that: four orphans from four "successful" runs drained
+			// the E2E wallet by ~811k credits before anyone looked (#88).
+			if (cleanupError) throw cleanupError;
 		}
 	);
 });


### PR DESCRIPTION
Ports [#122](https://github.com/NiKrause/simple-todo/pull/122) into `collab01`. **Chapter-local commit — no merge from main.**

## The bug

`relay-button-provisioning.spec.js` drove cleanup, caught any failure, wrote it into the evidence — and dropped it:

```js
} catch (cleanupError) {
  updateRelayEvidenceStep(evidence, 'cleanup', 'failed', detail);
  progress(`cleanup FAILED: ${detail}`);
}          // ← nothing rethrown
```

A run that left an Aleph VM running therefore reported **success**. Observed on main today (run 30751650708): the first attempt's VM was erased correctly, a retry then created a second INSTANCE *after* cleanup had collected its list, `cleanup FAILED` was logged — and the workflow went green.

Four such green runs between 08:45 and 09:36 left four VMs behind. They drained the E2E wallet from 846,231 to 34,892 credits (~811k, roughly 747k/day) and were finally deallocated by Aleph for lack of funds rather than by cleanup. Every Aleph-deploying job failed with `error 6` meanwhile.

## The change

`cleanupError` is captured and rethrown after the existing `testError` rethrow:

- provisioning failed → that error still surfaces (it is the more informative one)
- provisioning passed, cleanup failed → the run goes **red**, naming the surviving instance

The message carries the instance name and the original error as `cause`, so the leaked VM is identifiable from the failure line alone.

## How this was ported

Not retyped: the diff from main's merged commit applied cleanly here. The pre-change `catch` block hashed byte-identical across `main`, `collab01`, `passkey01` and `acl01`, so the same patch is exact for each. Resulting diff here is 1 file, +15/−10 — the same as main. `prettier --check` passes on the file afterwards.

(`collab02` has no such spec and needs nothing.)

## Not verified

This cannot be proven green from the PR: `Relay button E2E` needs `RELAY_BUTTON_E2E_PRIVATE_KEY` and provisions a real VM, and the wallet is currently ~83.5k credits below the deploy threshold. Verified instead: the patch applied without fuzz, the rethrow is present, prettier is clean, and the existing `testError` path is untouched.

Refs #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)