### PR TITLE
Reach peers with an invite instead of a relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ The `main` branch is the basic shared-list demo. Every browser opens the same de
 4. **Wait for Connection** - The app will automatically discover and connect peers
 5. **Add Todos** - Create todos in one browser and watch them appear in the other
 
+### 📷 Connecting by invite instead of by relay
+
+Add `?transport=qr` to the URL and the app swaps its whole networking layer for a
+single WebRTC transport whose signalling is **a code someone holds up**. No relay,
+no bootstrap, no pubsub discovery, no pinning — this peer cannot find anybody by
+itself, and nobody can find it.
+
+Two peers meet by one creating an invite and the other scanning it (or pasting
+it, on a device without a camera), then handing the reply back the same way. The
+invite is signed with the peer's own key and carries the DTLS fingerprint, so
+accepting one is what authenticates the other side — there is no relay in the
+middle to be trusted or to fail.
+
+What makes it worth trying: open two windows in that mode, write a few todos in
+each *before* connecting, and they stay apart. Exchange the invite and both
+screens hold everything either of them wrote. Nothing merged — every peer opens
+the same content-addressed database, so the two were always writing to one log
+that had no way to replicate. Connecting is what lets it.
+
+The transport and the on-screen elements come from
+[`@le-space/libp2p-webrtc-qr`](https://github.com/NiKrause/libp2p-webrtc-qr);
+the security model of that handshake is written up in
+[connection-security.md](https://github.com/NiKrause/libp2p-webrtc-qr/blob/main/docs/connection-security.md).
+
 ## 📚 Documentation
 
 For comprehensive guides on how this app works, implementation details, and reusable components:

--- a/e2e/qr-invite-merge.spec.js
+++ b/e2e/qr-invite-merge.spec.js
@@ -95,6 +95,12 @@ async function openInviteOnlyApp(page) {
  */
 async function exchangeInvite(alice, bob) {
 	await alice.getByTestId('qr-create-invite').click();
+
+	// The invite is shown as a code by <qr-invite>, themed from outside in this
+	// app's own palette - which is the acceptance criterion #38 asks for and the
+	// only way to know the custom properties actually cross the shadow boundary.
+	await expect(alice.getByTestId('qr-code')).toBeVisible({ timeout });
+	await expect(alice.locator('qr-code img, [data-testid="qr-code"] img').first()).toBeVisible({ timeout });
 	await expect
 		.poll(() => alice.getByTestId('qr-outgoing').inputValue(), { timeout })
 		.not.toHaveLength(0);

--- a/e2e/qr-invite-merge.spec.js
+++ b/e2e/qr-invite-merge.spec.js
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Two lists that could not see each other, joined by a scanned code.
+ *
+ * `?transport=qr` strips this app down to one transport: no relay, no
+ * bootstrap, no pubsub discovery, nothing that can find a peer by itself. That
+ * is what makes the result mean something - if these two peers end up sharing a
+ * list, the invite is the only thing that could have introduced them, and the
+ * test proves the isolation before it proves the merge.
+ *
+ * What is *not* happening: two databases becoming one. Every peer on `main`
+ * opens `simple-todos` with `write: ['*']`, and that manifest is content
+ * addressed, so both peers computed the same OrbitDB address before they ever
+ * met. Alice and Bob are writing to one log that has not replicated yet.
+ * Connecting is what lets it - which is a stronger claim than a merge, because
+ * nothing has to reconcile.
+ */
+
+const timeout = 90000;
+
+test.describe('Invite-only collaboration', () => {
+	test('two isolated todo lists become one after an invite is exchanged', async ({ browser }) => {
+		test.setTimeout(timeout * 4);
+
+		const aliceContext = await browser.newContext();
+		const bobContext = await browser.newContext();
+		const alice = await aliceContext.newPage();
+		const bob = await bobContext.newPage();
+
+		const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+		const aliceTodos = [`alice-${runId}-1`, `alice-${runId}-2`];
+		const bobTodos = [`bob-${runId}-1`, `bob-${runId}-2`];
+
+		try {
+			await Promise.all([openInviteOnlyApp(alice), openInviteOnlyApp(bob)]);
+
+			// Each writes its own list while the other is unreachable.
+			for (const todo of aliceTodos) {
+				await addTodo(alice, todo);
+			}
+			for (const todo of bobTodos) {
+				await addTodo(bob, todo);
+			}
+
+			// The claim under test starts here: without the invite, neither list
+			// contains the other's entries. A test that skipped this would pass just
+			// as well if the two peers had met some other way.
+			await expectMissing(alice, bobTodos[0]);
+			await expectMissing(bob, aliceTodos[0]);
+			expect(await connectedPeerCount(alice)).toBe(0);
+			expect(await connectedPeerCount(bob)).toBe(0);
+
+			await exchangeInvite(alice, bob);
+
+			// One list on both screens, holding everything either of them wrote.
+			for (const todo of [...aliceTodos, ...bobTodos]) {
+				await expectTodo(alice, todo);
+				await expectTodo(bob, todo);
+			}
+
+			// ...and it stays live: something written after the merge shows up too.
+			const afterwards = `together-${runId}`;
+			await addTodo(bob, afterwards);
+			await expectTodo(alice, afterwards);
+		} finally {
+			await aliceContext.close();
+			await bobContext.close();
+		}
+	});
+});
+
+/** @param {import('@playwright/test').Page} page */
+async function openInviteOnlyApp(page) {
+	await page.goto('/?transport=qr');
+
+	const modal = page.locator('div.fixed.inset-0.z-50');
+	await expect(modal).toBeVisible();
+
+	for (const checkbox of await modal.locator('input[type="checkbox"]').all()) {
+		await checkbox.check();
+	}
+
+	await page.getByRole('button', { name: 'Proceed to Test the App' }).click();
+	await expect(modal).not.toBeVisible();
+	await expect(page.getByTestId('qr-connect')).toBeVisible();
+	await expect(getTodoInput(page)).toBeEnabled({ timeout });
+}
+
+/**
+ * The exchange a person would do by holding up a code and reading one back.
+ *
+ * @param {import('@playwright/test').Page} alice
+ * @param {import('@playwright/test').Page} bob
+ */
+async function exchangeInvite(alice, bob) {
+	await alice.getByTestId('qr-create-invite').click();
+	await expect
+		.poll(() => alice.getByTestId('qr-outgoing').inputValue(), { timeout })
+		.not.toHaveLength(0);
+
+	const invite = await alice.getByTestId('qr-outgoing').inputValue();
+
+	await bob.getByTestId('qr-incoming').fill(invite);
+	await bob.getByTestId('qr-use-payload').click();
+	await expect
+		.poll(() => bob.getByTestId('qr-outgoing').inputValue(), { timeout })
+		.not.toHaveLength(0);
+
+	const reply = await bob.getByTestId('qr-outgoing').inputValue();
+
+	await alice.getByTestId('qr-incoming').fill(reply);
+	await alice.getByTestId('qr-use-payload').click();
+	await expect(alice.getByTestId('qr-status')).toContainText('Connected', { timeout });
+
+	await expect.poll(() => connectedPeerCount(alice), { timeout }).toBeGreaterThan(0);
+	await expect.poll(() => connectedPeerCount(bob), { timeout }).toBeGreaterThan(0);
+}
+
+/** @param {import('@playwright/test').Page} page */
+function connectedPeerCount(page) {
+	return page.evaluate(() => {
+		const node = /** @type {any} */ (window).__libp2p ?? null;
+
+		return node?.getConnections().length ?? 0;
+	});
+}
+
+/** @param {import('@playwright/test').Page} page */
+function getTodoInput(page) {
+	return page.getByPlaceholder('What needs to be done?');
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {string} text
+ */
+async function addTodo(page, text) {
+	await getTodoInput(page).fill(text);
+	await page.getByRole('button', { name: 'Add TODO' }).click();
+	await expectTodo(page, text);
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {string} text
+ */
+async function expectTodo(page, text) {
+	await expect(page.getByText(text, { exact: true })).toBeVisible({ timeout });
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {string} text
+ */
+async function expectMissing(page, text) {
+	// Long enough that replication would have happened if it were going to.
+	await page.waitForTimeout(4000);
+	await expect(page.getByText(text, { exact: true })).toHaveCount(0);
+}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"@ipld/dag-cbor": "^10.0.1",
 		"@ipld/dag-json": "^11.0.0",
 		"@le-space/aleph-bootstrap": "0.7.0",
-		"@le-space/libp2p-webrtc-qr": "link:../libp2p-webrtc-qr/packages/webrtc-qr",
+		"@le-space/libp2p-webrtc-qr": "^0.4.0",
 		"@le-space/orbitdb-identity-provider-webauthn-did": "0.3.1",
 		"@le-space/ui": "0.7.0",
 		"@libp2p/autonat": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"@ipld/dag-cbor": "^10.0.1",
 		"@ipld/dag-json": "^11.0.0",
 		"@le-space/aleph-bootstrap": "0.7.0",
-		"@le-space/libp2p-webrtc-qr": "link:../libp2p-webrtc-qr/packages/webrtc-qr",
+		"@le-space/libp2p-webrtc-qr": "^0.5.0",
 		"@le-space/orbitdb-identity-provider-webauthn-did": "0.3.1",
 		"@le-space/ui": "0.7.0",
 		"@libp2p/autonat": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"@ipld/dag-cbor": "^10.0.1",
 		"@ipld/dag-json": "^11.0.0",
 		"@le-space/aleph-bootstrap": "0.7.0",
-		"@le-space/libp2p-webrtc-qr": "^0.4.0",
+		"@le-space/libp2p-webrtc-qr": "link:../libp2p-webrtc-qr/packages/webrtc-qr",
 		"@le-space/orbitdb-identity-provider-webauthn-did": "0.3.1",
 		"@le-space/ui": "0.7.0",
 		"@libp2p/autonat": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"@ipld/dag-cbor": "^10.0.1",
 		"@ipld/dag-json": "^11.0.0",
 		"@le-space/aleph-bootstrap": "0.7.0",
+		"@le-space/libp2p-webrtc-qr": "link:../libp2p-webrtc-qr/packages/webrtc-qr",
 		"@le-space/orbitdb-identity-provider-webauthn-did": "0.3.1",
 		"@le-space/ui": "0.7.0",
 		"@libp2p/autonat": "^3.0.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(typescript@5.9.2)
       '@le-space/libp2p-webrtc-qr':
-        specifier: link:../libp2p-webrtc-qr/packages/webrtc-qr
-        version: link:../libp2p-webrtc-qr/packages/webrtc-qr
+        specifier: ^0.4.0
+        version: 0.4.0(@multiformats/multiaddr@13.0.3)(libp2p@3.3.6)
       '@le-space/orbitdb-identity-provider-webauthn-did':
         specifier: 0.3.1
         version: 0.3.1(@orbitdb/core@4.0.0)(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
@@ -993,6 +993,12 @@ packages:
 
   '@le-space/iso-webauthn-varsig@0.2.0':
     resolution: {integrity: sha512-8sVwcu5yvSKkGZhaXzCA8eSim+TKwMBvz25sNkqGZsUkRIh1s5/PszyjO3C/CZasowHLIouaaLb/xd5VQUNzNw==}
+
+  '@le-space/libp2p-webrtc-qr@0.4.0':
+    resolution: {integrity: sha512-KRS9tgUmlFLdld+tQra6BKZLn07WkdYAlrVCPoR6wL3FbAcDbaZhiiZKfCAWPV01y9byTbjuI125HaJ6TZbiWA==}
+    peerDependencies:
+      '@multiformats/multiaddr': ^13.0.3
+      libp2p: ^3.3.7
 
   '@le-space/node@0.7.0':
     resolution: {integrity: sha512-V5uBTzpzyANgQ4eAs11vfhxjf/cRl/bJJ+uQdH7sfvwoZmwDgbvNMRzzmH9fhgL5nJIKORzRqTIIr7Gv2YPbPA==}
@@ -6385,6 +6391,24 @@ snapshots:
   '@le-space/iso-webauthn-varsig@0.2.0':
     dependencies:
       iso-base: '@le-space/iso-base@4.3.0'
+
+  '@le-space/libp2p-webrtc-qr@0.4.0(@multiformats/multiaddr@13.0.3)(libp2p@3.3.6)':
+    dependencies:
+      '@libp2p/interface': 3.2.5
+      '@libp2p/peer-id': 6.0.13
+      '@libp2p/utils': 7.3.1
+      '@multiformats/multiaddr': 13.0.3
+      it-length-prefixed: 11.0.1
+      it-pushable: 3.2.4
+      libp2p: 3.3.6
+      p-defer: 4.0.1
+      p-event: 7.1.0
+      p-timeout: 7.0.1
+      protons-runtime: 7.0.0
+      race-signal: 2.0.0
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
   '@le-space/node@0.7.0(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(typescript@5.9.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(typescript@5.9.2)
       '@le-space/libp2p-webrtc-qr':
-        specifier: ^0.4.0
-        version: 0.4.0(@multiformats/multiaddr@13.0.3)(libp2p@3.3.6)
+        specifier: link:../libp2p-webrtc-qr/packages/webrtc-qr
+        version: link:../libp2p-webrtc-qr/packages/webrtc-qr
       '@le-space/orbitdb-identity-provider-webauthn-did':
         specifier: 0.3.1
         version: 0.3.1(@orbitdb/core@4.0.0)(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
@@ -993,12 +993,6 @@ packages:
 
   '@le-space/iso-webauthn-varsig@0.2.0':
     resolution: {integrity: sha512-8sVwcu5yvSKkGZhaXzCA8eSim+TKwMBvz25sNkqGZsUkRIh1s5/PszyjO3C/CZasowHLIouaaLb/xd5VQUNzNw==}
-
-  '@le-space/libp2p-webrtc-qr@0.4.0':
-    resolution: {integrity: sha512-KRS9tgUmlFLdld+tQra6BKZLn07WkdYAlrVCPoR6wL3FbAcDbaZhiiZKfCAWPV01y9byTbjuI125HaJ6TZbiWA==}
-    peerDependencies:
-      '@multiformats/multiaddr': ^13.0.3
-      libp2p: ^3.3.7
 
   '@le-space/node@0.7.0':
     resolution: {integrity: sha512-V5uBTzpzyANgQ4eAs11vfhxjf/cRl/bJJ+uQdH7sfvwoZmwDgbvNMRzzmH9fhgL5nJIKORzRqTIIr7Gv2YPbPA==}
@@ -6391,24 +6385,6 @@ snapshots:
   '@le-space/iso-webauthn-varsig@0.2.0':
     dependencies:
       iso-base: '@le-space/iso-base@4.3.0'
-
-  '@le-space/libp2p-webrtc-qr@0.4.0(@multiformats/multiaddr@13.0.3)(libp2p@3.3.6)':
-    dependencies:
-      '@libp2p/interface': 3.2.5
-      '@libp2p/peer-id': 6.0.13
-      '@libp2p/utils': 7.3.1
-      '@multiformats/multiaddr': 13.0.3
-      it-length-prefixed: 11.0.1
-      it-pushable: 3.2.4
-      libp2p: 3.3.6
-      p-defer: 4.0.1
-      p-event: 7.1.0
-      p-timeout: 7.0.1
-      protons-runtime: 7.0.0
-      race-signal: 2.0.0
-      uint8-varint: 3.0.0
-      uint8arraylist: 3.0.2
-      uint8arrays: 6.1.1
 
   '@le-space/node@0.7.0(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(typescript@5.9.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@le-space/aleph-bootstrap':
         specifier: 0.7.0
         version: 0.7.0(typescript@5.9.2)
+      '@le-space/libp2p-webrtc-qr':
+        specifier: link:../libp2p-webrtc-qr/packages/webrtc-qr
+        version: link:../libp2p-webrtc-qr/packages/webrtc-qr
       '@le-space/orbitdb-identity-provider-webauthn-did':
         specifier: 0.3.1
         version: 0.3.1(@orbitdb/core@4.0.0)(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
@@ -5797,7 +5800,7 @@ snapshots:
       '@libp2p/interface': 3.2.5
       '@libp2p/logger': 6.2.10
       '@libp2p/peer-collections': 7.0.24
-      '@libp2p/utils': 7.3.0
+      '@libp2p/utils': 7.3.1
       '@multiformats/multiaddr': 13.0.3
       any-signal: 4.2.0
       interface-blockstore: 6.0.2
@@ -5855,8 +5858,8 @@ snapshots:
       '@helia/interface': 6.2.1
       '@helia/utils': 2.5.2
       '@libp2p/interface': 3.2.5
-      '@libp2p/peer-id': 6.0.12
-      '@libp2p/utils': 7.3.0
+      '@libp2p/peer-id': 6.0.13
+      '@libp2p/utils': 7.3.1
       '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       '@multiformats/multiaddr-to-uri': 12.0.0
@@ -5880,7 +5883,7 @@ snapshots:
   '@helia/delegated-routing-v1-http-api-client@6.0.1':
     dependencies:
       '@libp2p/interface': 3.2.5
-      '@libp2p/peer-id': 6.0.12
+      '@libp2p/peer-id': 6.0.13
       '@multiformats/multiaddr': 13.0.3
       any-signal: 4.2.0
       browser-readablestream-to-it: 2.0.12
@@ -5992,7 +5995,7 @@ snapshots:
       '@helia/delegated-routing-v1-http-api-client': 6.0.1
       '@helia/interface': 6.2.1
       '@libp2p/interface': 3.2.5
-      '@libp2p/peer-id': 6.0.12
+      '@libp2p/peer-id': 6.0.13
       '@multiformats/uri-to-multiaddr': 10.0.0
       ipns: 10.1.6
       it-first: 3.0.11
@@ -6022,7 +6025,7 @@ snapshots:
       '@ipld/dag-pb': 4.1.7
       '@libp2p/interface': 3.2.5
       '@libp2p/logger': 6.2.10
-      '@libp2p/utils': 7.3.0
+      '@libp2p/utils': 7.3.1
       '@multiformats/murmur3': 2.2.8
       interface-blockstore: 6.0.2
       ipfs-unixfs: 12.0.2
@@ -6076,7 +6079,7 @@ snapshots:
       '@ipld/dag-pb': 4.1.7
       '@libp2p/interface': 3.2.5
       '@libp2p/keychain': 6.1.4
-      '@libp2p/utils': 7.3.0
+      '@libp2p/utils': 7.3.1
       '@multiformats/dns': 1.0.15
       '@multiformats/multiaddr': 13.0.3
       any-signal: 4.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(typescript@5.9.2)
       '@le-space/libp2p-webrtc-qr':
-        specifier: link:../libp2p-webrtc-qr/packages/webrtc-qr
-        version: link:../libp2p-webrtc-qr/packages/webrtc-qr
+        specifier: ^0.5.0
+        version: 0.5.0(@multiformats/multiaddr@13.0.3)(libp2p@3.3.6)
       '@le-space/orbitdb-identity-provider-webauthn-did':
         specifier: 0.3.1
         version: 0.3.1(@orbitdb/core@4.0.0)(rollup@4.46.2)(vite@7.0.6(@types/node@26.1.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.49.0)(yaml@2.9.0))
@@ -993,6 +993,12 @@ packages:
 
   '@le-space/iso-webauthn-varsig@0.2.0':
     resolution: {integrity: sha512-8sVwcu5yvSKkGZhaXzCA8eSim+TKwMBvz25sNkqGZsUkRIh1s5/PszyjO3C/CZasowHLIouaaLb/xd5VQUNzNw==}
+
+  '@le-space/libp2p-webrtc-qr@0.5.0':
+    resolution: {integrity: sha512-42kEoLNUpkp2RMp/yihMS1g8lj0LO41oDIGJmKhN+fHwTH4i5qBNjWLTb94GJkZO7K2dwkVQuxT+X+lfllgNqw==}
+    peerDependencies:
+      '@multiformats/multiaddr': ^13.0.3
+      libp2p: ^3.3.7
 
   '@le-space/node@0.7.0':
     resolution: {integrity: sha512-V5uBTzpzyANgQ4eAs11vfhxjf/cRl/bJJ+uQdH7sfvwoZmwDgbvNMRzzmH9fhgL5nJIKORzRqTIIr7Gv2YPbPA==}
@@ -6385,6 +6391,24 @@ snapshots:
   '@le-space/iso-webauthn-varsig@0.2.0':
     dependencies:
       iso-base: '@le-space/iso-base@4.3.0'
+
+  '@le-space/libp2p-webrtc-qr@0.5.0(@multiformats/multiaddr@13.0.3)(libp2p@3.3.6)':
+    dependencies:
+      '@libp2p/interface': 3.2.5
+      '@libp2p/peer-id': 6.0.13
+      '@libp2p/utils': 7.3.1
+      '@multiformats/multiaddr': 13.0.3
+      it-length-prefixed: 11.0.1
+      it-pushable: 3.2.4
+      libp2p: 3.3.6
+      p-defer: 4.0.1
+      p-event: 7.1.0
+      p-timeout: 7.0.1
+      protons-runtime: 7.0.0
+      race-signal: 2.0.0
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
   '@le-space/node@0.7.0(react-native@0.80.2(@babel/core@7.29.7)(react@19.2.6))(typescript@5.9.2)':
     dependencies:

--- a/src/lib/QrConnect.svelte
+++ b/src/lib/QrConnect.svelte
@@ -1,0 +1,117 @@
+<script>
+	import { onMount } from 'svelte';
+	import { getQrSession, isQrTransportMode } from './qr-transport.js';
+
+	let visible = $state(false);
+	let outgoing = $state('');
+	let incoming = $state('');
+	let status = $state('Create an invite, or paste the one you were given.');
+	let busy = $state(false);
+
+	onMount(() => {
+		visible = isQrTransportMode();
+	});
+
+	function session() {
+		const current = getQrSession();
+
+		if (current == null) {
+			throw new Error('The peer is still starting');
+		}
+
+		return current;
+	}
+
+	async function createInvite() {
+		busy = true;
+		try {
+			outgoing = await session().createOffer();
+			status = 'Send this invite. Paste their reply below when it comes back.';
+		} catch (/** @type {any} */ error) {
+			status = `Could not create an invite: ${error.message}`;
+		} finally {
+			busy = false;
+		}
+	}
+
+	/**
+	 * One box for both directions. Which one a payload is decides itself - an
+	 * offer produces a reply, a reply completes the connection - and asking the
+	 * user to know which of the two they were handed is asking the wrong person.
+	 */
+	async function usePayload() {
+		const text = incoming.trim();
+
+		if (text.length === 0) {
+			return;
+		}
+
+		busy = true;
+		try {
+			if (outgoing.length > 0) {
+				const { peerId } = await session().acceptAnswer(text);
+
+				// `acceptAnswer` gets WebRTC up and puts the upgrade context in place;
+				// the libp2p connection appears when something dials. This app has no
+				// protocol of its own to open - OrbitDB and gossipsub simply use
+				// whatever connection exists - so dial the peer itself.
+				await session().dial(peerId);
+				status = `Connected to ${peerId.slice(0, 12)}…`;
+			} else {
+				outgoing = await session().acceptOffer(text);
+				status = 'Send this reply back to them.';
+			}
+			incoming = '';
+		} catch (/** @type {any} */ error) {
+			status = `That payload was rejected: ${error.message}`;
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+{#if visible}
+	<section
+		class="mb-4 rounded-lg border border-amber-400/40 bg-amber-50 p-4 dark:bg-gray-800"
+		data-testid="qr-connect"
+	>
+		<h2 class="mb-1 text-sm font-semibold">Connect by invite</h2>
+		<p class="mb-3 text-xs text-gray-600 dark:text-gray-300">
+			No relay, no discovery. This peer meets others only through an invite you exchange yourself.
+		</p>
+
+		<div class="flex flex-wrap gap-2">
+			<button
+				class="rounded bg-amber-500 px-3 py-1 text-sm text-white disabled:opacity-50"
+				onclick={createInvite}
+				disabled={busy}
+				data-testid="qr-create-invite">Create invite</button
+			>
+		</div>
+
+		<textarea
+			class="mt-3 w-full rounded border p-2 font-mono text-xs dark:bg-gray-900"
+			rows="2"
+			readonly
+			data-testid="qr-outgoing"
+			value={outgoing}
+		></textarea>
+
+		<textarea
+			class="mt-2 w-full rounded border p-2 font-mono text-xs dark:bg-gray-900"
+			rows="2"
+			placeholder="Paste their invite or reply here"
+			data-testid="qr-incoming"
+			bind:value={incoming}
+		></textarea>
+
+		<button
+			class="mt-2 rounded border px-3 py-1 text-sm disabled:opacity-50"
+			onclick={usePayload}
+			disabled={busy}
+			data-testid="qr-use-payload">Use this</button
+		>
+
+		<p class="mt-2 text-xs" data-testid="qr-status">{status}</p>
+	</section>
+{/if}

--- a/src/lib/QrConnect.svelte
+++ b/src/lib/QrConnect.svelte
@@ -5,11 +5,21 @@
 	let visible = $state(false);
 	let outgoing = $state('');
 	let incoming = $state('');
-	let status = $state('Create an invite, or paste the one you were given.');
+	let status = $state('Create an invite, or scan the code they are showing you.');
 	let busy = $state(false);
+	/** @type {any} */
+	let scanner = $state(null);
 
-	onMount(() => {
+	onMount(async () => {
 		visible = isQrTransportMode();
+
+		if (!visible) {
+			return;
+		}
+
+		// Loaded in the browser only: SvelteKit renders this page on the server
+		// first, where `customElements` does not exist.
+		await import('@le-space/libp2p-webrtc-qr/elements');
 	});
 
 	function session() {
@@ -26,7 +36,7 @@
 		busy = true;
 		try {
 			outgoing = await session().createOffer();
-			status = 'Send this invite. Paste their reply below when it comes back.';
+			status = 'Show this code, or send the text. Then scan their reply.';
 		} catch (/** @type {any} */ error) {
 			status = `Could not create an invite: ${error.message}`;
 		} finally {
@@ -35,30 +45,32 @@
 	}
 
 	/**
-	 * One box for both directions. Which one a payload is decides itself - an
-	 * offer produces a reply, a reply completes the connection - and asking the
+	 * One entry point for both directions. Which one a payload is decides itself -
+	 * an offer produces a reply, a reply completes the connection - and asking the
 	 * user to know which of the two they were handed is asking the wrong person.
+	 *
+	 * @param {string} text
 	 */
-	async function usePayload() {
-		const text = incoming.trim();
+	async function usePayload(text) {
+		const trimmed = text.trim();
 
-		if (text.length === 0) {
+		if (trimmed.length === 0) {
 			return;
 		}
 
 		busy = true;
 		try {
 			if (outgoing.length > 0) {
-				// 0.4.0 dials for us. Before that this had to be done by hand, because
-				// until something dials there is no libp2p connection at all - and this
-				// app has no protocol of its own to open, OrbitDB and gossipsub simply
-				// use whatever connection exists.
-				const { peerId } = await session().acceptAnswer(text);
+				// The session dials for us since 0.4.0: until something dials there is
+				// no libp2p connection, and this app has no protocol of its own to
+				// open - OrbitDB and gossipsub use whatever connection exists.
+				const { peerId } = await session().acceptAnswer(trimmed);
 
 				status = `Connected to ${peerId.slice(0, 12)}…`;
+				outgoing = '';
 			} else {
-				outgoing = await session().acceptOffer(text);
-				status = 'Send this reply back to them.';
+				outgoing = await session().acceptOffer(trimmed);
+				status = 'Show this reply back to them.';
 			}
 			incoming = '';
 		} catch (/** @type {any} */ error) {
@@ -66,6 +78,12 @@
 		} finally {
 			busy = false;
 		}
+	}
+
+	function scan() {
+		scanner?.open().catch((/** @type {any} */ error) => {
+			status = `Camera failed: ${error.message}`;
+		});
 	}
 </script>
 
@@ -86,7 +104,28 @@
 				disabled={busy}
 				data-testid="qr-create-invite">Create invite</button
 			>
+			<button
+				class="rounded border px-3 py-1 text-sm disabled:opacity-50"
+				onclick={scan}
+				disabled={busy}
+				data-testid="qr-scan">Scan their code</button
+			>
 		</div>
+
+		{#if outgoing}
+			<!--
+				Themed entirely from outside through custom properties - the element's
+				own defaults are dark, and this app is light by default. If those
+				properties did not cross the shadow boundary there would be no way to
+				do this without forking the element.
+			-->
+			<qr-invite
+				class="mt-3 block"
+				value={outgoing}
+				style="--qr-invite-max-width: 320px; --qr-invite-caption-color: #4b5563; --qr-invite-radius: 6px;"
+				data-testid="qr-code"
+			></qr-invite>
+		{/if}
 
 		<textarea
 			class="mt-3 w-full rounded border p-2 font-mono text-xs dark:bg-gray-900"
@@ -99,18 +138,25 @@
 		<textarea
 			class="mt-2 w-full rounded border p-2 font-mono text-xs dark:bg-gray-900"
 			rows="2"
-			placeholder="Paste their invite or reply here"
+			placeholder="Or paste their invite or reply here"
 			data-testid="qr-incoming"
 			bind:value={incoming}
 		></textarea>
 
 		<button
 			class="mt-2 rounded border px-3 py-1 text-sm disabled:opacity-50"
-			onclick={usePayload}
+			onclick={() => usePayload(incoming)}
 			disabled={busy}
 			data-testid="qr-use-payload">Use this</button
 		>
 
 		<p class="mt-2 text-xs" data-testid="qr-status">{status}</p>
+
+		<qr-scanner
+			bind:this={scanner}
+			label="Scan their code"
+			style="--qr-scanner-background: #ffffff; --qr-scanner-foreground: #111827; --qr-scanner-border: #d1d5db; --qr-scanner-status-color: #4b5563;"
+			onscan={(/** @type {any} */ event) => usePayload(event.detail.text)}
+		></qr-scanner>
 	</section>
 {/if}

--- a/src/lib/QrConnect.svelte
+++ b/src/lib/QrConnect.svelte
@@ -49,13 +49,12 @@
 		busy = true;
 		try {
 			if (outgoing.length > 0) {
+				// 0.4.0 dials for us. Before that this had to be done by hand, because
+				// until something dials there is no libp2p connection at all - and this
+				// app has no protocol of its own to open, OrbitDB and gossipsub simply
+				// use whatever connection exists.
 				const { peerId } = await session().acceptAnswer(text);
 
-				// `acceptAnswer` gets WebRTC up and puts the upgrade context in place;
-				// the libp2p connection appears when something dials. This app has no
-				// protocol of its own to open - OrbitDB and gossipsub simply use
-				// whatever connection exists - so dial the peer itself.
-				await session().dial(peerId);
 				status = `Connected to ${peerId.slice(0, 12)}…`;
 			} else {
 				outgoing = await session().acceptOffer(text);

--- a/src/lib/libp2p-config.js
+++ b/src/lib/libp2p-config.js
@@ -18,6 +18,7 @@ import {
 	parseBootstrapMultiaddrs,
 	selectValidBrowserBootstrapMultiaddrs
 } from './bootstrap-multiaddrs.js';
+import { isQrTransportMode, qrTransports } from './qr-transport.js';
 
 // Environment variables
 const RELAY_BOOTSTRAP_ADDR_DEV =
@@ -85,6 +86,12 @@ export async function createLibp2pConfig(privateKey = null) {
 		} catch (error) {
 			console.warn('Invalid test peer ID, generating random key:', error);
 		}
+	}
+
+	// QR mode reaches peers with a scanned code and nothing else, so it needs no
+	// relay to bootstrap from - and demanding one would fail before it started.
+	if (isQrTransportMode()) {
+		return qrOnlyConfig(privateKey);
 	}
 
 	const relayBootstrapAddrs = selectValidBrowserBootstrapMultiaddrs(
@@ -184,6 +191,42 @@ export async function createLibp2pConfig(privateKey = null) {
 	}
 
 	return config;
+}
+
+/**
+ * One transport, no discovery, no relay.
+ *
+ * Everything removed here is a way for two peers to find each other without
+ * being introduced: bootstrap, pubsub discovery, autonat, dcutr, circuit relay,
+ * websockets. What is left cannot meet anybody by itself, which is the point -
+ * if two of these connect, the scanned code is the only thing that could have
+ * done it.
+ *
+ * Gossipsub stays, because it is not discovery here. OrbitDB exchanges heads
+ * over it, and without it two peers connect and then sit there with a database
+ * that never syncs.
+ *
+ * @param {any} privateKey
+ */
+function qrOnlyConfig(privateKey) {
+	return {
+		...(privateKey ? { privateKey } : {}),
+		addresses: { listen: [] },
+		transports: qrTransports(),
+		connectionEncrypters: [noise()],
+		streamMuxers: [yamux()],
+		peerDiscovery: [],
+		services: {
+			identify: identify(),
+			identifyPush: identifyPush(),
+			ping: ping({ timeout: 10_000 }),
+			pubsub: gossipsub({
+				emitSelf: false,
+				allowPublishToZeroTopicPeers: true,
+				canRelayMessage: true
+			})
+		}
+	};
 }
 
 // Usage example:

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -6,6 +6,7 @@ import { withBitswap } from '@helia/bitswap';
 import { withHTTP } from '@helia/http';
 import { withLibp2p } from '@helia/libp2p';
 import { createOrbitDB, IPFSAccessController } from '@orbitdb/core';
+import { attachQrSession, isQrTransportMode } from './qr-transport.js';
 import * as dagCbor from '@ipld/dag-cbor';
 import * as dagJson from '@ipld/dag-json';
 import * as json from 'multiformats/codecs/json';
@@ -147,6 +148,12 @@ export async function initializeP2P(options = /** @type {{ todoDbAddress?: strin
 		setInitializationProgress(1);
 		libp2p = await createLibp2p(config);
 		libp2pStore.set(libp2p); // Make available to plugins
+
+		// In QR mode the session is the only way this node will ever meet a peer,
+		// so it has to exist before anything tries to dial.
+		if (isQrTransportMode()) {
+			attachQrSession(libp2p);
+		}
 		console.log(`✅ libp2p node created`);
 
 		// Get and set peer ID

--- a/src/lib/qr-transport.js
+++ b/src/lib/qr-transport.js
@@ -1,0 +1,69 @@
+import { QRSession, webRTCQR } from '@le-space/libp2p-webrtc-qr';
+
+/**
+ * Reaching a peer with a scanned code and nothing else.
+ *
+ * This app normally finds peers through a relay: bootstrap, pubsub discovery,
+ * circuit reservations, pinning. `?transport=qr` removes all of it and leaves
+ * one transport whose signalling is a QR code someone held up.
+ *
+ * That is not a smaller version of the same thing. It is the opposite of it,
+ * which is what makes it worth having as a second consumer of the transport
+ * package - it asks where the seams actually are rather than confirming that
+ * the ones already drawn happen to fit.
+ *
+ * Two peers still open the *same* OrbitDB database, because on `main` every
+ * peer opens `simple-todos` with `write: ['*']` and that manifest is content
+ * addressed - the same name and access controller produce the same address for
+ * everyone. So Alice and Bob writing while unable to see each other are not
+ * building two lists that later merge. They are writing to one log that has not
+ * replicated yet, and connecting is what lets it.
+ */
+
+/** @type {QRSession | null} */
+let session = null;
+
+export function isQrTransportMode() {
+	if (typeof window === 'undefined') {
+		return false;
+	}
+
+	return new URLSearchParams(window.location.search).get('transport') === 'qr';
+}
+
+export function getQrSession() {
+	return session;
+}
+
+/**
+ * The transport list for QR mode: exactly one entry, and nothing that could
+ * find a peer by itself. If a test connects two of these, the code is the only
+ * thing that could have introduced them.
+ */
+export function qrTransports() {
+	return [webRTCQR({ getOutboundSession: (peerId) => session?.getOutboundSession(peerId) ?? null })];
+}
+
+/**
+ * @param {import('libp2p').Libp2p} node
+ */
+export function attachQrSession(node) {
+	// Isolation is the claim this mode makes, so a test has to be able to check
+	// it rather than take it on trust.
+	if (typeof window !== 'undefined') {
+		/** @type {any} */ (window).__libp2p = node;
+	}
+
+	session = new QRSession(node, {
+		rtcConfiguration: {
+			iceServers: [{ urls: ['stun:stun.l.google.com:19302', 'stun:stun.cloudflare.com:3478'] }]
+		}
+	});
+
+	return session;
+}
+
+export function resetQrSession() {
+	session?.close();
+	session = null;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,7 @@
 	import ErrorAlert from '$lib/ErrorAlert.svelte';
 	import AddTodoForm from '$lib/AddTodoForm.svelte';
 	import TodoList from '$lib/TodoList.svelte';
+	import QrConnect from '$lib/QrConnect.svelte';
 	import ConnectedPeers from '$lib/ConnectedPeers.svelte';
 	import PeerIdCard from '$lib/PeerIdCard.svelte';
 	import OwnMultiaddrs from '$lib/OwnMultiaddrs.svelte';
@@ -201,6 +202,8 @@
 	{/if}
 
 	<!-- Add TODO Form -->
+	<QrConnect />
+
 	<AddTodoForm on:add={handleAddTodo} disabled={!$initializationStore.isInitialized} />
 
 	<!-- TODO List -->


### PR DESCRIPTION
The second consumer that [libp2p-webrtc-qr#38](https://github.com/NiKrause/libp2p-webrtc-qr/issues/38) asks for — and deliberately the *opposite* of what this app does today. No relay, no bootstrap, no pubsub discovery, no pinning. One transport, whose signalling is a code someone held up.

That issue says a second consumer found late confirms the seams, while one found early moves them. This one moved a seam within an hour of existing.

## `?transport=qr`

Swaps the libp2p config for a single `webRTCQR` transport with **no peer discovery of any kind**. Gossipsub stays, because here it is not discovery: OrbitDB exchanges heads over it, and without it two peers connect and then sit with a database that never syncs.

## The test proves the isolation before it proves the merge

```
✓ two isolated todo lists become one after an invite is exchanged (39.2s)
```

Alice and Bob each write a list while unable to see each other. The test then asserts that neither list contains the other's entries **and that both have zero connections** — a test that skipped that would pass just as well if the two peers had met some other way. Only then is the invite exchanged, after which both screens show every entry, and something written *afterwards* still arrives, so the connection is live rather than a one-off catch-up.

Three consecutive runs, all green.

## What is actually happening, precisely

Two databases do not become one. Every peer on `main` opens `simple-todos` with `write: ['*']`, and that manifest is content addressed — so **both peers computed the same OrbitDB address before they ever met**. They were writing to one log that had not replicated. Connecting is what lets it.

That is a stronger claim than a merge, because nothing has to reconcile. It is also why this works at all without any new conflict handling.

## The seam it moved

`acceptAnswer` gets WebRTC up and puts the upgrade context in place, but the libp2p connection appears only when something **dials**. The demo dials its chat protocol and so never noticed; this app has no protocol of its own — OrbitDB and gossipsub just use whatever connection exists — so it dials the peer. The test caught it: status said *Connected*, `getConnections()` said `0`.

Worth feeding back into the package README, and an argument that `acceptAnswer` should perhaps dial by itself.

## Dependency status

~~Not mergeable as-is: the package is linked from the sibling checkout, because `QRSession` is not in the published `0.3.0`.~~ **Resolved.** `0.5.0` is published, and this branch installs it from npm like any other dependency — `"@le-space/libp2p-webrtc-qr": "^0.5.0"`, resolved in `pnpm-lock.yaml` against the registry with an integrity hash, no `link:` or `file:` anywhere. CI installs from that lockfile in a clean checkout, which is the actual proof it is installable elsewhere.
