### PR TITLE
feat(qr): offer Scan Connect SDP next to the Relay Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,29 +41,85 @@ The `main` branch is the basic shared-list demo. Every browser opens the same de
 4. **Wait for Connection** - The app will automatically discover and connect peers
 5. **Add Todos** - Create todos in one browser and watch them appear in the other
 
-### 📷 Connecting by invite instead of by relay
+## 🤝 Two ways to meet a peer
 
-Add `?transport=qr` to the URL and the app swaps its whole networking layer for a
-single WebRTC transport whose signalling is **a code someone holds up**. No relay,
-no bootstrap, no pubsub discovery, no pinning — this peer cannot find anybody by
-itself, and nobody can find it.
+The app carries **two independent introduction mechanisms**, and they answer
+different questions. Both are reachable from the floating buttons in the
+bottom-right corner.
 
-Two peers meet by one creating an invite and the other scanning it (or pasting
-it, on a device without a camera), then handing the reply back the same way. The
-invite is signed with the peer's own key and carries the DTLS fingerprint, so
-accepting one is what authenticates the other side — there is no relay in the
-middle to be trusted or to fail.
+|                                           | 🛰️ Relay Button                | 📷 Scan Connect SDP                       |
+| ----------------------------------------- | ------------------------------ | ----------------------------------------- |
+| **Question it answers**                   | "How do strangers find me?"    | "How do the two of us connect right now?" |
+| **Introduction via**                      | a relay you deploy and pay for | a code you hand over yourself             |
+| **Needs infrastructure**                  | yes — an Aleph VM              | no                                        |
+| **Works with peers you have never met**   | yes                            | no, someone must show you the code        |
+| **Keeps working after you close the tab** | yes, the relay stays           | no                                        |
 
-What makes it worth trying: open two windows in that mode, write a few todos in
-each *before* connecting, and they stay apart. Exchange the invite and both
-screens hold everything either of them wrote. Nothing merged — every peer opens
-the same content-addressed database, so the two were always writing to one log
-that had no way to replicate. Connecting is what lets it.
+They are **not alternatives**. A relay makes you continuously discoverable; an
+invite connects two people who are already talking to each other. Running both
+is the normal case, which is why `main` loads the QR transport alongside the
+relay transports rather than switching between them.
+
+### 🛰️ Relay Button
+
+Deploys a relay onto an [Aleph](https://aleph.im) VM from inside the browser,
+paid from your own wallet, and publishes its multiaddress so other browsers can
+bootstrap from it. Peers then find each other through pubsub discovery without
+ever having exchanged anything by hand. The button comes from
+[`@le-space/ui`](https://github.com/NiKrause/relay-button); the relay itself is
+[`orbitdb-relay`](https://github.com/NiKrause/orbitdb-relay).
+
+### 📷 Scan Connect SDP
+
+Opens a panel that negotiates a **direct WebRTC connection** through a code you
+exchange yourself. One peer presses _Create invite_ and shows the QR code (or
+copies the text, on a device without a camera); the other scans or pastes it and
+hands the reply back the same way.
+
+The invite is signed with the peer's own key and carries the DTLS fingerprint,
+so **accepting one is what authenticates the other side** — there is no relay in
+the middle to be trusted or to fail.
+
+What makes it worth trying: open two windows, write a few todos in each _before_
+connecting, and they stay apart. Exchange the invite and both screens hold
+everything either of them wrote. Nothing merged — every peer opens the same
+content-addressed database, so the two were always writing to one log that had
+no way to replicate. Connecting is what lets it.
 
 The transport and the on-screen elements come from
 [`@le-space/libp2p-webrtc-qr`](https://github.com/NiKrause/libp2p-webrtc-qr);
 the security model of that handshake is written up in
 [connection-security.md](https://github.com/NiKrause/libp2p-webrtc-qr/blob/main/docs/connection-security.md).
+
+#### `?transport=qr` — the isolated variant
+
+Adding `?transport=qr` to the URL builds a node with the QR transport and
+**nothing else**: no relay, no bootstrap, no pubsub discovery, no pinning. This
+peer cannot find anybody by itself, and nobody can find it.
+
+That mode exists so the claim is testable rather than taken on trust — if two
+such nodes end up connected, the code is provably the only thing that introduced
+them (`e2e/qr-invite-merge.spec.js`). In that mode the panel starts open, since
+there is no other way to connect.
+
+### Wiring
+
+Adding the invite path to a page is three pieces:
+
+```js
+// 1. the transport, next to the relay transports (src/lib/libp2p-config.js)
+transports: [webSockets(), webRTC(), circuitRelayTransport(...), webRTCQRTransport()];
+
+// 2. the session, before anything dials (src/lib/p2p.js)
+attachQrSession(libp2p);
+
+// 3. the UI (src/routes/+page.svelte)
+<QrConnect />;
+```
+
+`attachQrSession` must run at node startup, not on first click: the transport
+asks it for an outbound session while dialing, so a session created only when
+someone presses the button would arrive too late.
 
 ## 📚 Documentation
 

--- a/src/lib/QrConnect.svelte
+++ b/src/lib/QrConnect.svelte
@@ -2,7 +2,12 @@
 	import { onMount } from 'svelte';
 	import { getQrSession, isQrTransportMode } from './qr-transport.js';
 
-	let visible = $state(false);
+	// Mounted on every page now, not just under `?transport=qr`: the invite is a
+	// second way to meet a peer, next to the relay. What that flag still decides
+	// is whether the panel starts open — QR-only mode has no other way to connect,
+	// and its E2E expects the controls without a click.
+	let mounted = $state(false);
+	let open = $state(false);
 	let outgoing = $state('');
 	let incoming = $state('');
 	let status = $state('Create an invite, or scan the code they are showing you.');
@@ -11,15 +16,12 @@
 	let scanner = $state(null);
 
 	onMount(async () => {
-		visible = isQrTransportMode();
-
-		if (!visible) {
-			return;
-		}
+		open = isQrTransportMode();
 
 		// Loaded in the browser only: SvelteKit renders this page on the server
 		// first, where `customElements` does not exist.
 		await import('@le-space/libp2p-webrtc-qr/elements');
+		mounted = true;
 	});
 
 	function session() {
@@ -87,14 +89,35 @@
 	}
 </script>
 
-{#if visible}
+<!--
+	Sits directly under the Relay Button FAB, which the @le-space/ui launcher pins
+	at bottom 92.8px / right 22.4px with z-index 10000. Deliberately one notch
+	lower so the two never fight for the same pixels, and stacked rather than
+	side-by-side because the launcher is 166px wide and a row of both would
+	overflow a narrow phone.
+-->
+{#if mounted}
+	<button
+		class="fixed right-[22.4px] bottom-10 z-[9999] rounded-full bg-amber-500 px-4 py-2 text-sm font-medium tracking-wide whitespace-nowrap text-white shadow-lg hover:bg-amber-600"
+		onclick={() => (open = !open)}
+		data-testid="qr-toggle"
+		aria-expanded={open}
+		aria-controls="qr-connect-panel"
+	>
+		Scan Connect SDP
+	</button>
+{/if}
+
+{#if open}
 	<section
+		id="qr-connect-panel"
 		class="mb-4 rounded-lg border border-amber-400/40 bg-amber-50 p-4 dark:bg-gray-800"
 		data-testid="qr-connect"
 	>
 		<h2 class="mb-1 text-sm font-semibold">Connect by invite</h2>
 		<p class="mb-3 text-xs text-gray-600 dark:text-gray-300">
-			No relay, no discovery. This peer meets others only through an invite you exchange yourself.
+			A direct WebRTC connection negotiated through a code you hand over yourself — no relay and no
+			discovery involved in the introduction.
 		</p>
 
 		<div class="flex flex-wrap gap-2">

--- a/src/lib/libp2p-config.js
+++ b/src/lib/libp2p-config.js
@@ -18,7 +18,7 @@ import {
 	parseBootstrapMultiaddrs,
 	selectValidBrowserBootstrapMultiaddrs
 } from './bootstrap-multiaddrs.js';
-import { isQrTransportMode, qrTransports } from './qr-transport.js';
+import { isQrTransportMode, qrTransports, webRTCQRTransport } from './qr-transport.js';
 
 // Environment variables
 const RELAY_BOOTSTRAP_ADDR_DEV =
@@ -129,7 +129,13 @@ export async function createLibp2pConfig(privateKey = null) {
 					discoverRelays: 1,
 					reservationCompletionTimeout: 20_000
 				})
-			)
+			),
+			// The invite path rides alongside the relay path rather than replacing
+			// it: the relay is how strangers find you, an invite is how two people
+			// who are already talking connect directly. Without this transport here
+			// the "Scan Connect SDP" button could only work after reloading into
+			// `?transport=qr`, which is a different node with no relay at all.
+			webRTCQRTransport()
 		],
 		connectionEncrypters: [noise()],
 		connectionGater: {

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -6,7 +6,7 @@ import { withBitswap } from '@helia/bitswap';
 import { withHTTP } from '@helia/http';
 import { withLibp2p } from '@helia/libp2p';
 import { createOrbitDB, IPFSAccessController } from '@orbitdb/core';
-import { attachQrSession, isQrTransportMode } from './qr-transport.js';
+import { attachQrSession } from './qr-transport.js';
 import * as dagCbor from '@ipld/dag-cbor';
 import * as dagJson from '@ipld/dag-json';
 import * as json from 'multiformats/codecs/json';
@@ -149,11 +149,11 @@ export async function initializeP2P(options = /** @type {{ todoDbAddress?: strin
 		libp2p = await createLibp2p(config);
 		libp2pStore.set(libp2p); // Make available to plugins
 
-		// In QR mode the session is the only way this node will ever meet a peer,
-		// so it has to exist before anything tries to dial.
-		if (isQrTransportMode()) {
-			attachQrSession(libp2p);
-		}
+		// The session has to exist before anything tries to dial. In QR-only mode
+		// it is the single way this node will ever meet a peer; on `main` it backs
+		// the "Scan Connect SDP" button, which is useless if the session is only
+		// built once someone presses it.
+		attachQrSession(libp2p);
 		console.log(`✅ libp2p node created`);
 
 		// Get and set peer ID

--- a/src/lib/qr-transport.js
+++ b/src/lib/qr-transport.js
@@ -36,21 +36,34 @@ export function getQrSession() {
 }
 
 /**
- * The transport list for QR mode: exactly one entry, and nothing that could
+ * The transport on its own. `main` carries it next to the relay transports so an
+ * invite works without reloading the page into a different mode, which is what
+ * makes "Scan Connect SDP" a second way to meet a peer rather than a replacement
+ * for the relay.
+ */
+export function webRTCQRTransport() {
+	return webRTCQR({ getOutboundSession: (peerId) => session?.getOutboundSession(peerId) ?? null });
+}
+
+/**
+ * The transport list for QR-only mode: exactly one entry, and nothing that could
  * find a peer by itself. If a test connects two of these, the code is the only
- * thing that could have introduced them.
+ * thing that could have introduced them — which is why `?transport=qr` still
+ * builds a stripped node even though the transport now ships on `main` too.
  */
 export function qrTransports() {
-	return [webRTCQR({ getOutboundSession: (peerId) => session?.getOutboundSession(peerId) ?? null })];
+	return [webRTCQRTransport()];
 }
 
 /**
  * @param {import('libp2p').Libp2p} node
  */
 export function attachQrSession(node) {
-	// Isolation is the claim this mode makes, so a test has to be able to check
-	// it rather than take it on trust.
-	if (typeof window !== 'undefined') {
+	// Isolation is the claim QR-only mode makes, so a test has to be able to
+	// check it rather than take it on trust. Now that the session is attached on
+	// every page load, keep the handle scoped to that mode — a global pointer to
+	// the libp2p node on the production page serves nobody.
+	if (typeof window !== 'undefined' && isQrTransportMode()) {
 		/** @type {any} */ (window).__libp2p = node;
 	}
 


### PR DESCRIPTION
Follow-up to #126, which landed the invite path behind `?transport=qr`.

## Why the button was invisible

`?transport=qr` did not just reveal UI — it swapped the **entire** networking layer for a single transport with no relay, no bootstrap, no pubsub discovery. So on the normal page there was nothing to see, and reaching a peer by invite meant reloading into a node that could not use the relay at all. The two paths were mutually exclusive by construction.

## What changed

Both mechanisms now run on the same node, because they answer different questions:

| | 🛰️ Relay Button | 📷 Scan Connect SDP |
|---|---|---|
| Question | "How do strangers find me?" | "How do the two of us connect right now?" |
| Introduction via | a relay you deploy and pay for | a code you hand over yourself |
| Infrastructure | an Aleph VM | none |
| Survives closing the tab | yes | no |

- **`webRTCQRTransport()` joins the normal transport list** — the invite works without changing modes.
- **`attachQrSession` runs at node startup**, not only in QR mode. The transport asks it for an outbound session *while dialing*, so building one on first click would arrive too late. This is the part that actually makes the button work; without it the UI would be present and dead.
- **`QrConnect` renders a launcher under the Relay Button FAB.** Stacked rather than side by side: the relay launcher is 166px wide and a row of both overflows a narrow phone.
- **`window.__libp2p` is now scoped to `?transport=qr`.** It exists so the isolation test can inspect the node; a global pointer to the libp2p node on the production page serves nobody.

## The isolated mode is untouched

`?transport=qr` still builds a node with nothing but the QR transport, so the claim its E2E rests on — *if two of these connect, the code is provably the only thing that introduced them* — is unchanged. The panel starts open in that mode, since there is no other way to connect there, which also keeps `e2e/qr-invite-merge.spec.js` working without edits.

## Verification

Measured in the running app, both launchers right-aligned at `right: 22.4px`:

| | size | bottom | z-index |
|---|---|---|---|
| Relay Button | 115×51 | 92.8px | 10000 |
| Scan Connect SDP | 161×36 | 40px | 9999 |

16.8px apart, one notch lower so they never fight for the same pixels.

- `e2e/qr-invite-merge.spec.js` — **passes** (10.5s), so the isolated mode still connects two nodes by code alone.
- `e2e/default-database-collaboration.spec.js` + `e2e/consent-screen.spec.js` — **4 passed** (1.6m). This is the regression that mattered: the default relay path is unaffected by the extra transport.
- 14 unit tests pass, `vite build` succeeds, prettier and eslint clean.
- Toggle verified in the browser: `aria-expanded` flips and all six controls appear; under `?transport=qr` the panel is open on load.

## Not verified

The invite has not been exercised **between the relay path and the QR path on one node** — i.e. a peer connected through the relay *and* by invite at the same time. The E2E covers each in isolation. Nothing suggests a conflict (they are independent transports), but I would not claim it works until someone has done it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)