### PR TITLE
feat: choose relay network or invite-only on consent, and share invites as links

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,25 @@ ever having exchanged anything by hand. The button comes from
 
 ### 📷 Scan Connect SDP
 
-Opens a panel that negotiates a **direct WebRTC connection** through a code you
-exchange yourself. One peer presses _Create invite_ and shows the QR code (or
-copies the text, on a device without a camera); the other scans or pastes it and
-hands the reply back the same way.
+Opens a panel that negotiates a **direct WebRTC connection** through an invite
+you exchange yourself. One peer presses _Create invite_ and hands it over in
+whichever form fits:
+
+- **the QR code** — the other device scans it;
+- **the text** — paste it into a chat;
+- **_Copy invite link_** — send a URL. Opening it applies the invite by itself,
+  through the consent screen if the recipient is new, and works while their app
+  is already open (the fragment change is handled, not ignored).
+
+Either way the recipient hands the reply back the same way, and that completes
+the connection.
+
+The link carries the payload in the **fragment**, never the query string. A
+fragment is not sent to the server, and this app is served from public IPFS
+gateways as well as its own domain — a query string would hand a signed
+connection offer to every operator on the way and into their logs. The fragment
+is also cleared once used, so a reload cannot replay a spent offer. Measured in
+the E2E: a payload is around **1.1 kB**, so a link stays comfortably shareable.
 
 The invite is signed with the peer's own key and carries the DTLS fingerprint,
 so **accepting one is what authenticates the other side** — there is no relay in

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ invite connects two people who are already talking to each other. Running both
 is the normal case, which is why `main` loads the QR transport alongside the
 relay transports rather than switching between them.
 
+### Choosing on the consent screen
+
+The consent screen carries a checkbox — **"Connect to the public libp2p relay
+network"**, on by default:
+
+- **On** (default): the browser bootstraps from the public relay and finds peers
+  through pubsub discovery. The invite panel is still available on top of that.
+- **Off**: the node starts with the QR transport and nothing else — no relay, no
+  bootstrap, no discovery, no pinning. Nothing announces this browser and nobody
+  can find it; the only way in or out is an invite you exchange yourself, so the
+  panel opens by itself.
+
+It is deliberately **not** one of the "I understand…" boxes and never blocks the
+proceed button: those are acknowledgements, this is a choice, and unticking it is
+a valid way to continue rather than a refusal to consent.
+
+The choice is stored per browser (`localStorage`), because consent can be
+remembered — in which case the modal never renders again and the node starts
+straight from `onMount`. A preference that lived only in the modal would be
+unreachable for exactly the people who visit most often.
+
 ### 🛰️ Relay Button
 
 Deploys a relay onto an [Aleph](https://aleph.im) VM from inside the browser,
@@ -93,9 +114,10 @@ the security model of that handshake is written up in
 
 #### `?transport=qr` — the isolated variant
 
-Adding `?transport=qr` to the URL builds a node with the QR transport and
-**nothing else**: no relay, no bootstrap, no pubsub discovery, no pinning. This
-peer cannot find anybody by itself, and nobody can find it.
+Adding `?transport=qr` to the URL forces the same invite-only node the consent
+checkbox produces, and **overrides a stored preference of "on"**. A URL that
+promises no relay must not quietly grow one because this browser once ticked a
+box.
 
 That mode exists so the claim is testable rather than taken on trust — if two
 such nodes end up connected, the code is provably the only thing that introduced

--- a/e2e/qr-invite-merge.spec.js
+++ b/e2e/qr-invite-merge.spec.js
@@ -68,21 +68,90 @@ test.describe('Invite-only collaboration', () => {
 			await bobContext.close();
 		}
 	});
+
+	// The same handshake without a camera: Alice sends a link, Bob opens it. The
+	// payload rides in the fragment, so nothing about the offer reaches a server
+	// or an IPFS gateway on the way.
+	test('an invite link connects a browser that never saw the code', async ({ browser }) => {
+		test.setTimeout(timeout * 4);
+
+		const aliceContext = await browser.newContext();
+		// Bob is a genuinely fresh browser whose first act is opening the link —
+		// which is what "sent someone an invite" actually looks like.
+		const bobContext = await browser.newContext();
+		const alice = await aliceContext.newPage();
+		const bob = await bobContext.newPage();
+
+		const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+		const aliceTodo = `alice-link-${runId}`;
+
+		try {
+			await openInviteOnlyApp(alice);
+			await addTodo(alice, aliceTodo);
+
+			await alice.getByTestId('qr-create-invite').click();
+			await expect
+				.poll(() => alice.getByTestId('qr-outgoing').inputValue(), { timeout })
+				.not.toHaveLength(0);
+
+			const invite = await alice.getByTestId('qr-outgoing').inputValue();
+			const link = `/?transport=qr#invite=${encodeURIComponent(invite)}`;
+
+			// Recorded rather than asserted against a threshold: whether a payload
+			// still fits a link is a property of the codec, and a number in the log
+			// is what makes a future regression legible.
+			console.log(`[qr-link] invite payload ${invite.length} chars, link ${link.length} chars`);
+
+			// No pasting, no scanning — and the consent screen comes first, so the
+			// invite has to survive a wait for a node that does not exist yet.
+			await bob.goto(link);
+			await acceptConsent(bob);
+			await expect(bob.getByTestId('qr-connect')).toBeVisible({ timeout });
+			await expect
+				.poll(() => bob.getByTestId('qr-outgoing').inputValue(), { timeout })
+				.not.toHaveLength(0);
+
+			// The spent offer must not survive in the address bar, or a reload would
+			// replay it.
+			expect(await bob.evaluate(() => window.location.hash)).toBe('');
+
+			const reply = await bob.getByTestId('qr-outgoing').inputValue();
+
+			await alice.getByTestId('qr-incoming').fill(reply);
+			await alice.getByTestId('qr-use-payload').click();
+			await expect(alice.getByTestId('qr-status')).toContainText('Connected', { timeout });
+
+			// Bob never saw this todo by any other route.
+			await expectTodo(bob, aliceTodo);
+		} finally {
+			await aliceContext.close();
+			await bobContext.close();
+		}
+	});
 });
 
 /** @param {import('@playwright/test').Page} page */
-async function openInviteOnlyApp(page) {
-	await page.goto('/?transport=qr');
-
+async function acceptConsent(page) {
 	const modal = page.locator('div.fixed.inset-0.z-50');
 	await expect(modal).toBeVisible();
 
-	for (const checkbox of await modal.locator('input[type="checkbox"]').all()) {
+	// Only the "I understand…" acknowledgements — they are the ones without a
+	// testid. The other two boxes are not consent: `consent-relay-network`
+	// chooses how to connect and is already on, and ticking `consent-remember`
+	// would persist the decision, so the modal would not reappear when a page
+	// reloads through an invite link — skipping the very state under test.
+	for (const checkbox of await modal.locator('input[type="checkbox"]:not([data-testid])').all()) {
 		await checkbox.check();
 	}
 
 	await page.getByRole('button', { name: 'Proceed to Test the App' }).click();
 	await expect(modal).not.toBeVisible();
+}
+
+/** @param {import('@playwright/test').Page} page */
+async function openInviteOnlyApp(page) {
+	await page.goto('/?transport=qr');
+	await acceptConsent(page);
 	await expect(page.getByTestId('qr-connect')).toBeVisible();
 	await expect(getTodoInput(page)).toBeEnabled({ timeout });
 }
@@ -100,7 +169,9 @@ async function exchangeInvite(alice, bob) {
 	// app's own palette - which is the acceptance criterion #38 asks for and the
 	// only way to know the custom properties actually cross the shadow boundary.
 	await expect(alice.getByTestId('qr-code')).toBeVisible({ timeout });
-	await expect(alice.locator('qr-code img, [data-testid="qr-code"] img').first()).toBeVisible({ timeout });
+	await expect(alice.locator('qr-code img, [data-testid="qr-code"] img').first()).toBeVisible({
+		timeout
+	});
 	await expect
 		.poll(() => alice.getByTestId('qr-outgoing').inputValue(), { timeout })
 		.not.toHaveLength(0);

--- a/src/lib/ConsentModal.svelte
+++ b/src/lib/ConsentModal.svelte
@@ -147,6 +147,7 @@
 						<input
 							type="checkbox"
 							bind:checked={rememberDecision}
+							data-testid="consent-remember"
 							class="mt-1 h-4 w-4 rounded text-cyan-600 focus:ring-cyan-500"
 						/>
 						<span class="text-text">{rememberLabel}</span>

--- a/src/lib/ConsentModal.svelte
+++ b/src/lib/ConsentModal.svelte
@@ -52,6 +52,16 @@
 	export let rememberDecision = false;
 	export let rememberLabel = "Don't show this again on this device";
 
+	/**
+	 * A choice, not an acknowledgement — which is why it sits outside
+	 * `checkboxes` and never blocks the proceed button. Unticking it is a valid
+	 * way to continue, not a refusal to consent.
+	 */
+	export let relayNetworkEnabled = true;
+	export let relayNetworkLabel = 'Connect to the public libp2p relay network';
+	export let relayNetworkHint =
+		'On: peers find each other automatically through public relay and bootstrap nodes. Off: this browser connects only to peers you invite yourself with a QR code or a copied invite — nothing announces you, and nobody can find you.';
+
 	$: allCheckboxesChecked = Object.values(checkboxes).every((item) => item.checked);
 
 	const handleProceed = () => {
@@ -118,6 +128,21 @@
 				</div>
 
 				<div class="mt-6 border-t border-border pt-4">
+					<label class="flex cursor-pointer items-start space-x-3">
+						<input
+							type="checkbox"
+							bind:checked={relayNetworkEnabled}
+							data-testid="consent-relay-network"
+							class="mt-1 h-4 w-4 rounded text-cyan-600 focus:ring-cyan-500"
+						/>
+						<span>
+							<span class="text-text">{relayNetworkLabel}</span>
+							<span class="mt-1 block text-sm text-faint">{relayNetworkHint}</span>
+						</span>
+					</label>
+				</div>
+
+				<div class="mt-4 border-t border-border pt-4">
 					<label class="flex cursor-pointer items-start space-x-3">
 						<input
 							type="checkbox"

--- a/src/lib/QrConnect.svelte
+++ b/src/lib/QrConnect.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { getQrSession } from './qr-transport.js';
 	import { isRelayNetworkMode } from './network-mode.js';
+	import { buildInviteLink, clearInviteLink, readInviteLink } from './invite-link.js';
 
 	// Mounted on every page: the invite is a second way to meet a peer, next to
 	// the relay. Whether the panel *starts* open depends on whether there is any
@@ -16,6 +17,7 @@
 	let busy = $state(false);
 	/** @type {any} */
 	let scanner = $state(null);
+	let linkCopied = $state(false);
 
 	onMount(async () => {
 		open = !isRelayNetworkMode();
@@ -24,7 +26,75 @@
 		// first, where `customElements` does not exist.
 		await import('@le-space/libp2p-webrtc-qr/elements');
 		mounted = true;
+
+		// Someone opened a link that carries an invite. Show them what is
+		// happening rather than connecting invisibly, and consume the fragment so
+		// a reload does not replay a spent offer.
+		await consumeInviteLink();
+
+		// Opening an invite link while this page is already loaded only changes the
+		// fragment, which is a same-document navigation: no reload, no onMount. The
+		// invite would be silently ignored without this.
+		window.addEventListener('hashchange', () => {
+			void consumeInviteLink();
+		});
 	});
+
+	async function consumeInviteLink() {
+		const invited = readInviteLink();
+
+		if (invited) {
+			open = true;
+			clearInviteLink();
+			status = 'Invite received. Waiting for this peer to start…';
+
+			// A first-time visitor lands on the consent screen, so at this point
+			// there is usually no libp2p node yet — accepting consent is what
+			// creates it. Applying the invite here would fail before the user had
+			// any chance to act on it.
+			if (await waitForSession()) {
+				await usePayload(invited);
+			} else {
+				status = 'Invite received, but this peer never finished starting. Reload to try again.';
+			}
+		}
+	}
+
+	/**
+	 * Resolves once the QR session exists, or false if it never does.
+	 *
+	 * Polls rather than subscribing to `libp2pStore`: that store is set one line
+	 * *before* `attachQrSession`, so reacting to it would still be a hair early.
+	 *
+	 * @param {number} [timeoutMs]
+	 */
+	async function waitForSession(timeoutMs = 120_000) {
+		const deadline = Date.now() + timeoutMs;
+
+		while (Date.now() < deadline) {
+			if (getQrSession() != null) {
+				return true;
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+
+		return false;
+	}
+
+	async function copyInviteLink() {
+		try {
+			await navigator.clipboard.writeText(buildInviteLink(outgoing));
+			linkCopied = true;
+			status = 'Link copied. Send it to them — opening it connects their browser to yours.';
+		} catch (/** @type {any} */ error) {
+			// Clipboard access is denied in plenty of ordinary situations (no
+			// secure context, no user gesture). The link is still in the box below,
+			// so say so instead of failing silently.
+			linkCopied = false;
+			status = `Could not copy: ${error.message}. Copy the invite text below instead.`;
+		}
+	}
 
 	function session() {
 		const current = getQrSession();
@@ -38,6 +108,7 @@
 
 	async function createInvite() {
 		busy = true;
+		linkCopied = false;
 		try {
 			outgoing = await session().createOffer();
 			status = 'Show this code, or send the text. Then scan their reply.';
@@ -159,6 +230,20 @@
 			data-testid="qr-outgoing"
 			value={outgoing}
 		></textarea>
+
+		{#if outgoing}
+			<!--
+				A link for the case the camera is not an option: a different device,
+				a chat window, a phone call. The payload rides in the fragment, so it
+				never reaches the server or an IPFS gateway on the way.
+			-->
+			<button
+				class="mt-2 rounded border px-3 py-1 text-sm disabled:opacity-50"
+				onclick={copyInviteLink}
+				disabled={busy}
+				data-testid="qr-copy-link">{linkCopied ? 'Link copied' : 'Copy invite link'}</button
+			>
+		{/if}
 
 		<textarea
 			class="mt-2 w-full rounded border p-2 font-mono text-xs dark:bg-gray-900"

--- a/src/lib/QrConnect.svelte
+++ b/src/lib/QrConnect.svelte
@@ -1,11 +1,13 @@
 <script>
 	import { onMount } from 'svelte';
-	import { getQrSession, isQrTransportMode } from './qr-transport.js';
+	import { getQrSession } from './qr-transport.js';
+	import { isRelayNetworkMode } from './network-mode.js';
 
-	// Mounted on every page now, not just under `?transport=qr`: the invite is a
-	// second way to meet a peer, next to the relay. What that flag still decides
-	// is whether the panel starts open — QR-only mode has no other way to connect,
-	// and its E2E expects the controls without a click.
+	// Mounted on every page: the invite is a second way to meet a peer, next to
+	// the relay. Whether the panel *starts* open depends on whether there is any
+	// other way to connect — with the relay network switched off (consent screen,
+	// or `?transport=qr`) an invite is the only one, so opening it is the whole
+	// interface rather than an extra.
 	let mounted = $state(false);
 	let open = $state(false);
 	let outgoing = $state('');
@@ -16,7 +18,7 @@
 	let scanner = $state(null);
 
 	onMount(async () => {
-		open = isQrTransportMode();
+		open = !isRelayNetworkMode();
 
 		// Loaded in the browser only: SvelteKit renders this page on the server
 		// first, where `customElements` does not exist.

--- a/src/lib/invite-link.js
+++ b/src/lib/invite-link.js
@@ -1,0 +1,74 @@
+/**
+ * Sharing an invite as a link instead of a code held up to a camera.
+ *
+ * The payload rides in the URL **fragment**, never the query string. A fragment
+ * is not sent to the server, and this app is served from `le-space.de` and from
+ * public IPFS gateways alike — putting a signed connection offer in the query
+ * would hand it to every gateway operator and into their access logs, for no
+ * benefit. The receiving page reads it locally and nothing else ever sees it.
+ */
+const FRAGMENT_KEY = 'invite';
+
+/**
+ * @param {string} payload
+ * @param {string} [href] defaults to the current location
+ * @returns {string}
+ */
+export function buildInviteLink(
+	payload,
+	href = typeof location === 'undefined' ? '' : location.href
+) {
+	const url = new URL(href);
+
+	// A link built from a page that already carries an invite must not stack a
+	// second one, and query parameters like `?transport=qr` stay untouched —
+	// they describe the mode the receiver should open in.
+	url.hash = `${FRAGMENT_KEY}=${encodeURIComponent(payload)}`;
+
+	return url.toString();
+}
+
+/**
+ * The invite carried by a URL, or null when there is none.
+ *
+ * @param {string} [href] defaults to the current location
+ * @returns {string | null}
+ */
+export function readInviteLink(href = typeof location === 'undefined' ? '' : location.href) {
+	if (!href) {
+		return null;
+	}
+
+	let hash;
+	try {
+		hash = new URL(href).hash;
+	} catch {
+		return null;
+	}
+
+	const params = new URLSearchParams(hash.replace(/^#/u, ''));
+	const payload = params.get(FRAGMENT_KEY);
+
+	return payload && payload.trim().length > 0 ? payload : null;
+}
+
+/**
+ * Drop the invite from the address bar once it has been consumed.
+ *
+ * Without this a reload would replay a spent offer, and the payload would sit in
+ * the browser's history and in whatever the user copies out of the address bar
+ * next. `replaceState` rather than assigning `location.hash`, which would push a
+ * history entry and fire a navigation.
+ */
+export function clearInviteLink() {
+	if (typeof window === 'undefined' || typeof history === 'undefined') {
+		return;
+	}
+
+	try {
+		history.replaceState(null, '', `${location.pathname}${location.search}`);
+	} catch {
+		// Sandboxed frames can refuse history access; a stale fragment is a far
+		// smaller problem than failing to connect.
+	}
+}

--- a/src/lib/invite-link.spec.js
+++ b/src/lib/invite-link.spec.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildInviteLink, readInviteLink } from './invite-link.js';
+
+// Shaped like a real payload: base64-ish with characters that must survive a
+// round trip through a URL (`+` would otherwise decode back as a space).
+const PAYLOAD = 'eyJ0eXAiOiJvZmZlciJ9.aGVsbG8+d29ybGQ/Zm9v=';
+
+describe('buildInviteLink', () => {
+	it('puts the payload in the fragment, never the query', () => {
+		const link = buildInviteLink(PAYLOAD, 'https://simple-todo.le-space.de/');
+		const url = new URL(link);
+
+		// A fragment is not sent to the server. This app is also served from
+		// public IPFS gateways, so a query string would hand a signed connection
+		// offer to every operator on the way and into their logs.
+		expect(url.search).toBe('');
+		expect(url.hash.startsWith('#invite=')).toBe(true);
+		expect(link).not.toContain('?invite=');
+	});
+
+	it('round-trips a payload containing URL-significant characters', () => {
+		const link = buildInviteLink(PAYLOAD, 'https://simple-todo.le-space.de/');
+
+		expect(readInviteLink(link)).toBe(PAYLOAD);
+	});
+
+	it('keeps the query string, so ?transport=qr survives being shared', () => {
+		const link = buildInviteLink(PAYLOAD, 'https://simple-todo.le-space.de/?transport=qr');
+
+		expect(new URL(link).search).toBe('?transport=qr');
+		expect(readInviteLink(link)).toBe(PAYLOAD);
+	});
+
+	it('replaces an existing invite instead of stacking a second one', () => {
+		const first = buildInviteLink('older', 'https://simple-todo.le-space.de/');
+		const second = buildInviteLink(PAYLOAD, first);
+
+		expect(readInviteLink(second)).toBe(PAYLOAD);
+		expect(second.match(/invite=/gu)).toHaveLength(1);
+	});
+});
+
+describe('readInviteLink', () => {
+	it('returns null when the URL carries no invite', () => {
+		expect(readInviteLink('https://simple-todo.le-space.de/')).toBe(null);
+		expect(readInviteLink('https://simple-todo.le-space.de/#other=1')).toBe(null);
+		expect(readInviteLink('https://simple-todo.le-space.de/?invite=wrong-place')).toBe(null);
+	});
+
+	it('treats an empty or blank invite as absent', () => {
+		expect(readInviteLink('https://simple-todo.le-space.de/#invite=')).toBe(null);
+		expect(readInviteLink('https://simple-todo.le-space.de/#invite=%20%20')).toBe(null);
+	});
+
+	it('does not throw on a malformed URL', () => {
+		expect(readInviteLink('not a url')).toBe(null);
+		expect(readInviteLink('')).toBe(null);
+	});
+});

--- a/src/lib/libp2p-config.js
+++ b/src/lib/libp2p-config.js
@@ -18,7 +18,8 @@ import {
 	parseBootstrapMultiaddrs,
 	selectValidBrowserBootstrapMultiaddrs
 } from './bootstrap-multiaddrs.js';
-import { isQrTransportMode, qrTransports, webRTCQRTransport } from './qr-transport.js';
+import { qrTransports, webRTCQRTransport } from './qr-transport.js';
+import { isRelayNetworkMode } from './network-mode.js';
 
 // Environment variables
 const RELAY_BOOTSTRAP_ADDR_DEV =
@@ -88,9 +89,10 @@ export async function createLibp2pConfig(privateKey = null) {
 		}
 	}
 
-	// QR mode reaches peers with a scanned code and nothing else, so it needs no
-	// relay to bootstrap from - and demanding one would fail before it started.
-	if (isQrTransportMode()) {
+	// Invite-only mode reaches peers with a scanned code and nothing else, so it
+	// needs no relay to bootstrap from - and demanding one would fail before it
+	// started. Chosen on the consent screen, or forced by `?transport=qr`.
+	if (!isRelayNetworkMode()) {
 		return qrOnlyConfig(privateKey);
 	}
 

--- a/src/lib/network-mode.js
+++ b/src/lib/network-mode.js
@@ -1,0 +1,62 @@
+import { isQrTransportMode } from './qr-transport.js';
+
+/**
+ * Which of the two introduction mechanisms this browser uses.
+ *
+ * The choice is made on the consent screen and has to outlive it: consent can be
+ * remembered, in which case the modal never renders again and `initializeP2P()`
+ * runs straight from `onMount`. A choice that lived only in the modal would be
+ * unreachable for exactly the users who visit most often.
+ */
+const STORAGE_KEY = 'simpleTodo.relayNetworkEnabled';
+
+/**
+ * Defaults to true: the relay network is what makes this a demo two strangers
+ * can try, and switching it off leaves a node nobody can reach without an
+ * invite handed over by other means.
+ *
+ * @returns {boolean}
+ */
+export function getRelayNetworkEnabled() {
+	if (typeof localStorage === 'undefined') {
+		return true;
+	}
+
+	try {
+		return localStorage.getItem(STORAGE_KEY) !== 'false';
+	} catch {
+		// Private browsing modes can throw on access rather than return null.
+		return true;
+	}
+}
+
+/**
+ * @param {boolean} enabled
+ */
+export function setRelayNetworkEnabled(enabled) {
+	if (typeof localStorage === 'undefined') {
+		return;
+	}
+
+	try {
+		localStorage.setItem(STORAGE_KEY, enabled ? 'true' : 'false');
+	} catch {
+		// Not being able to remember the choice is survivable; the session still
+		// honours it because the caller passes it on directly.
+	}
+}
+
+/**
+ * `?transport=qr` still wins over the stored preference. It is the isolated mode
+ * the E2E relies on, and a URL that promises "no relay" must not quietly grow
+ * one because this browser once ticked a box.
+ *
+ * @returns {boolean}
+ */
+export function isRelayNetworkMode() {
+	if (isQrTransportMode()) {
+		return false;
+	}
+
+	return getRelayNetworkEnabled();
+}

--- a/src/lib/network-mode.spec.js
+++ b/src/lib/network-mode.spec.js
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	getRelayNetworkEnabled,
+	isRelayNetworkMode,
+	setRelayNetworkEnabled
+} from './network-mode.js';
+
+const STORAGE_KEY = 'simpleTodo.relayNetworkEnabled';
+
+describe('relay network preference', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('defaults to on, so a first visit joins the public relay network', () => {
+		expect(getRelayNetworkEnabled()).toBe(true);
+	});
+
+	it('round-trips the choice so a remembered consent still honours it', () => {
+		// The modal never renders again once consent is remembered, so the stored
+		// value is the only carrier of the decision on later visits.
+		setRelayNetworkEnabled(false);
+		expect(getRelayNetworkEnabled()).toBe(false);
+
+		setRelayNetworkEnabled(true);
+		expect(getRelayNetworkEnabled()).toBe(true);
+	});
+
+	it('treats only an explicit "false" as off', () => {
+		// Anything else — absent, empty, garbage from an older build — must not
+		// silently strand a browser with no way to reach a peer.
+		localStorage.setItem(STORAGE_KEY, 'nonsense');
+		expect(getRelayNetworkEnabled()).toBe(true);
+
+		localStorage.setItem(STORAGE_KEY, 'false');
+		expect(getRelayNetworkEnabled()).toBe(false);
+	});
+
+	it('survives storage that throws instead of returning null', () => {
+		// Private browsing modes can reject access outright; the app has to start
+		// anyway rather than fail before the first render.
+		vi.stubGlobal('localStorage', {
+			getItem() {
+				throw new Error('access denied');
+			},
+			setItem() {
+				throw new Error('access denied');
+			}
+		});
+
+		expect(getRelayNetworkEnabled()).toBe(true);
+		expect(() => setRelayNetworkEnabled(false)).not.toThrow();
+	});
+});
+
+describe('isRelayNetworkMode', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		window.history.replaceState({}, '', '/');
+	});
+
+	it('follows the stored preference on a normal URL', () => {
+		expect(isRelayNetworkMode()).toBe(true);
+
+		setRelayNetworkEnabled(false);
+		expect(isRelayNetworkMode()).toBe(false);
+	});
+
+	it('lets ?transport=qr override a stored preference of on', () => {
+		// That URL promises a node with no relay at all — the mode the isolation
+		// E2E rests on. A box ticked once in this browser must not grow one back.
+		setRelayNetworkEnabled(true);
+		window.history.replaceState({}, '', '/?transport=qr');
+
+		expect(isRelayNetworkMode()).toBe(false);
+	});
+});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	/* eslint-disable no-undef */
 	import { onMount } from 'svelte';
 	import { peerIdStore, initializeP2P, initializationStore } from '$lib/p2p.js';
+	import { getRelayNetworkEnabled, setRelayNetworkEnabled } from '$lib/network-mode.js';
 	import { todosStore, addTodo, deleteTodo, toggleTodoComplete } from '$lib/db-actions.js';
 	import ConsentModal from '$lib/ConsentModal.svelte';
 	import SocialIcons from '$lib/SocialIcons.svelte';
@@ -38,9 +39,15 @@
 	// Modal state
 	let showModal = true;
 	let rememberDecision = false;
+	// Seeded from storage so the box reflects this browser's existing choice
+	// rather than resetting to the default on every visit.
+	let relayNetworkEnabled = getRelayNetworkEnabled();
 
 	const handleModalClose = async () => {
 		showModal = false;
+		// Written before initializeP2P: createLibp2pConfig reads the choice while
+		// building the node, so persisting it afterwards would start the wrong one.
+		setRelayNetworkEnabled(relayNetworkEnabled);
 		try {
 			if (rememberDecision) {
 				localStorage.setItem(CONSENT_KEY, 'true');
@@ -138,9 +145,7 @@
 <ToastNotification message={toastMessage} type={toastType} />
 
 <svelte:head>
-	<title
-		>Simple-Todo {typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0'}</title
-	>
+	<title>Simple-Todo {typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0'}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta
 		name="description"
@@ -153,6 +158,7 @@
 	<ConsentModal
 		bind:show={showModal}
 		title="Simple-Todo"
+		bind:relayNetworkEnabled
 		bind:rememberDecision
 		rememberLabel="Don't show this again on this device"
 		proceedButtonText="Proceed to Test the App"


### PR DESCRIPTION
Two commits, both about making the invite path something a person can actually reach and use. Follow-up to #127.

## 1. The choice moves to the consent screen

The invite path existed but the *choice* was only reachable by editing the URL. The consent screen now carries **"Connect to the public libp2p relay network"**, on by default:

- **On** — bootstraps from the public relay, finds peers through pubsub discovery. The invite panel is still available on top.
- **Off** — the node starts with the QR transport and **nothing else**: no relay, no bootstrap, no discovery, no pinning. Nothing announces this browser and nobody can find it, so the invite panel opens by itself.

**It is not one of the "I understand…" boxes and never disables the proceed button.** Those acknowledge what the demo does to your data; this is a choice about how to run it. In `checkboxes` it would have made "I don't want a relay" indistinguishable from "I don't agree".

**The preference is persisted.** `initializeP2P()` has two entry points: after the modal, and straight from `onMount` when consent was remembered. In the second case the modal never renders, so a choice living only in the component would be unreachable for the people who visit most often. Written *before* the node starts, because `createLibp2pConfig` reads it synchronously while building.

**`?transport=qr` still overrides a stored preference of on** — that URL promises a node with no relay and carries the isolation E2E.

## 2. Invites can be shared as links

A camera is not always an option. *Copy invite link* produces a URL that applies the invite on the other side by itself.

The payload rides in the **fragment**, never the query string: a fragment is not sent to the server, and this app is served from public IPFS gateways as well as its own domain — a query string would hand a signed connection offer to every operator on the way and into their logs. The fragment is cleared once consumed, so a reload cannot replay a spent offer.

**Writing the E2E surfaced two timing bugs that would have hit real users:**

- A first-time visitor lands on the consent screen, so when the link is read there is **no libp2p node yet** — accepting consent is what creates it. Applying the invite there failed before the user could act. It now waits for the session.
- Opening a link while the app is **already loaded** only changes the fragment, which is a same-document navigation: no reload, no `onMount`. Without a `hashchange` listener the invite was silently ignored.

Neither was visible from the code; both came out of the test failing.

## Verification

- **13 new unit tests** (`network-mode.spec.js` 6, `invite-link.spec.js` 7); **27 pass overall**. They cover the unpleasant cases: only an explicit `"false"` counts as relay-off (garbage from an older build must not strand a browser with no way to reach a peer), storage that *throws* rather than returning null (private browsing), payloads containing `+` and `/` surviving the URL round trip, and a fragment that must not stack two invites.
- **New E2E**: a genuinely fresh browser whose first act is opening the link — through consent, auto-applied, reply back, and Alice's todo arrives. It also asserts the fragment is cleared, and logs the size: **payload 1093 chars, link 1119** — comfortably shareable.
- `qr-invite-merge.spec.js` both cases pass; `consent-screen` + `default-database-collaboration` pass.
- In the browser: checkbox present and checked by default; toggling it leaves the proceed button enabled in **both** states.
- `vite build`, prettier, eslint clean.

## Worth flagging

`default-database-collaboration.spec.js` failed **once** on `toHaveAttribute` while running paired with `consent-screen`, then passed on two subsequent runs (alone and paired). I could not reproduce it and did not capture which attribute. Recording it rather than calling it unrelated — it is the relay-path test, so it is the one this change could plausibly disturb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)