### PR TITLE
test(e2e): reach invite-only mode through the consent screen

### DIFF
--- a/e2e/qr-invite-merge.spec.js
+++ b/e2e/qr-invite-merge.spec.js
@@ -3,11 +3,16 @@ import { test, expect } from '@playwright/test';
 /**
  * Two lists that could not see each other, joined by a scanned code.
  *
- * `?transport=qr` strips this app down to one transport: no relay, no
- * bootstrap, no pubsub discovery, nothing that can find a peer by itself. That
- * is what makes the result mean something - if these two peers end up sharing a
- * list, the invite is the only thing that could have introduced them, and the
- * test proves the isolation before it proves the merge.
+ * Both peers get here the way a user does: they untick "Connect to the public
+ * libp2p relay network" on the consent screen and then press "Scan Connect SDP".
+ * That leaves one transport - no relay, no bootstrap, no pubsub discovery,
+ * nothing that can find a peer by itself. Which is what makes the result mean
+ * something: if these two end up sharing a list, the invite is the only thing
+ * that could have introduced them, and the test proves the isolation before it
+ * proves the merge.
+ *
+ * `?transport=qr` reaches the same node and still works, but it is a developer
+ * shortcut - testing through it would leave the route real users take unproven.
  *
  * What is *not* happening: two databases becoming one. Every peer on `main`
  * opens `simple-todos` with `write: ['*']`, and that manifest is content
@@ -95,7 +100,7 @@ test.describe('Invite-only collaboration', () => {
 				.not.toHaveLength(0);
 
 			const invite = await alice.getByTestId('qr-outgoing').inputValue();
-			const link = `/?transport=qr#invite=${encodeURIComponent(invite)}`;
+			const link = `/#invite=${encodeURIComponent(invite)}`;
 
 			// Recorded rather than asserted against a threshold: whether a payload
 			// still fits a link is a property of the codec, and a number in the log
@@ -105,7 +110,7 @@ test.describe('Invite-only collaboration', () => {
 			// No pasting, no scanning — and the consent screen comes first, so the
 			// invite has to survive a wait for a node that does not exist yet.
 			await bob.goto(link);
-			await acceptConsent(bob);
+			await acceptConsent(bob, { relayNetwork: false });
 			await expect(bob.getByTestId('qr-connect')).toBeVisible({ timeout });
 			await expect
 				.poll(() => bob.getByTestId('qr-outgoing').inputValue(), { timeout })
@@ -130,28 +135,51 @@ test.describe('Invite-only collaboration', () => {
 	});
 });
 
-/** @param {import('@playwright/test').Page} page */
-async function acceptConsent(page) {
+/**
+ * Walk the consent screen the way a person does, and switch the relay network
+ * off there rather than through `?transport=qr`. That URL is a developer
+ * shortcut; the checkbox is the route real users take, and it is what has to
+ * actually produce an isolated node.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+async function acceptConsent(page, { relayNetwork = true } = {}) {
 	const modal = page.locator('div.fixed.inset-0.z-50');
 	await expect(modal).toBeVisible();
 
 	// Only the "I understand…" acknowledgements — they are the ones without a
-	// testid. The other two boxes are not consent: `consent-relay-network`
-	// chooses how to connect and is already on, and ticking `consent-remember`
-	// would persist the decision, so the modal would not reappear when a page
-	// reloads through an invite link — skipping the very state under test.
+	// testid. Ticking `consent-remember` would persist the decision, so the modal
+	// would not reappear when a page reloads through an invite link, skipping the
+	// very state under test.
 	for (const checkbox of await modal.locator('input[type="checkbox"]:not([data-testid])').all()) {
 		await checkbox.check();
 	}
 
-	await page.getByRole('button', { name: 'Proceed to Test the App' }).click();
+	const relayBox = page.getByTestId('consent-relay-network');
+	await expect(relayBox).toBeChecked();
+
+	if (!relayNetwork) {
+		await relayBox.uncheck();
+	}
+
+	// Unticking it must never block the button — it is a choice, not consent.
+	const proceed = page.getByRole('button', { name: 'Proceed to Test the App' });
+	await expect(proceed).toBeEnabled();
+	await proceed.click();
 	await expect(modal).not.toBeVisible();
 }
 
 /** @param {import('@playwright/test').Page} page */
 async function openInviteOnlyApp(page) {
-	await page.goto('/?transport=qr');
-	await acceptConsent(page);
+	await page.goto('/');
+	await acceptConsent(page, { relayNetwork: false });
+
+	// The panel is closed here, and that is not an oversight: the component reads
+	// the preference when it mounts, which happens while the consent screen is
+	// still up and the stored value is still the default. Opening it is what the
+	// "Scan Connect SDP" button is for.
+	await expect(page.getByTestId('qr-connect')).toHaveCount(0);
+	await page.getByTestId('qr-toggle').click();
 	await expect(page.getByTestId('qr-connect')).toBeVisible();
 	await expect(getTodoInput(page)).toBeEnabled({ timeout });
 }

--- a/src/lib/p2p.js
+++ b/src/lib/p2p.js
@@ -7,6 +7,7 @@ import { withHTTP } from '@helia/http';
 import { withLibp2p } from '@helia/libp2p';
 import { createOrbitDB, IPFSAccessController } from '@orbitdb/core';
 import { attachQrSession } from './qr-transport.js';
+import { isRelayNetworkMode } from './network-mode.js';
 import * as dagCbor from '@ipld/dag-cbor';
 import * as dagJson from '@ipld/dag-json';
 import * as json from 'multiformats/codecs/json';
@@ -153,7 +154,7 @@ export async function initializeP2P(options = /** @type {{ todoDbAddress?: strin
 		// it is the single way this node will ever meet a peer; on `main` it backs
 		// the "Scan Connect SDP" button, which is useless if the session is only
 		// built once someone presses it.
-		attachQrSession(libp2p);
+		attachQrSession(libp2p, { exposeDebugHandle: !isRelayNetworkMode() });
 		console.log(`✅ libp2p node created`);
 
 		// Get and set peer ID

--- a/src/lib/qr-transport.js
+++ b/src/lib/qr-transport.js
@@ -57,13 +57,19 @@ export function qrTransports() {
 
 /**
  * @param {import('libp2p').Libp2p} node
+ * @param {{ exposeDebugHandle?: boolean }} [options]
  */
-export function attachQrSession(node) {
-	// Isolation is the claim QR-only mode makes, so a test has to be able to
-	// check it rather than take it on trust. Now that the session is attached on
-	// every page load, keep the handle scoped to that mode — a global pointer to
-	// the libp2p node on the production page serves nobody.
-	if (typeof window !== 'undefined' && isQrTransportMode()) {
+export function attachQrSession(node, options = {}) {
+	// Isolation is the claim invite-only mode makes, so a test has to be able to
+	// check it rather than take it on trust.
+	//
+	// The caller decides whether to expose it, because that mode is reachable two
+	// ways — `?transport=qr` or the consent checkbox — and a handle tied to only
+	// one of them would let an isolation assertion pass *vacuously*: reading zero
+	// connections because the node is invisible to the test rather than because
+	// the peers are apart. Off on a relay-connected page, where a global pointer
+	// to the libp2p node serves nobody.
+	if (typeof window !== 'undefined' && options.exposeDebugHandle === true) {
 		/** @type {any} */ (window).__libp2p = node;
 	}
 


### PR DESCRIPTION
The invite E2E entered through `?transport=qr`, so the route users actually take — untick **"Connect to the public libp2p relay network"**, then press **"Scan Connect SDP"** — was never exercised. Both tests now walk that path.

## A trap this surfaced

`window.__libp2p` was exposed only under `?transport=qr`, and `connectedPeerCount()` reads it. Entering by checkbox would have left it `undefined`, so this assertion:

```js
expect(await connectedPeerCount(alice)).toBe(0);
```

would have passed **vacuously** — reading zero because the node was invisible to the test, not because the peers were apart. A test whose entire point is proving isolation would have proven nothing while staying green.

The handle now follows the *mode* rather than the URL. `attachQrSession` takes the decision from its caller instead of computing it, because `network-mode.js` already imports `qr-transport.js` and reversing that would close an import cycle. It stays off on a relay-connected page, which was the original reason for scoping it.

The assertion is self-evidencing now: `exchangeInvite` ends with `toBeGreaterThan(0)` on the same counter, so a missing handle fails the test rather than hiding in it.

## A behaviour worth stating

After consent the panel is **closed**, and the test asserts that rather than tolerating it:

```js
await expect(page.getByTestId('qr-connect')).toHaveCount(0);
await page.getByTestId('qr-toggle').click();
```

`QrConnect` reads the preference when it mounts — which happens while the consent modal is still up and the stored value is still the default. So on the visit where the choice is *made*, the panel does not open by itself; pressing the button is what opens it. It does open by itself on later visits, and when arriving through an invite link. My earlier description of this ("the panel opens by itself when the relay is off") was true only for those later cases.

## Verification

- `qr-invite-merge.spec.js` — **2 passed** through the consent route. Payload 1098 chars, link 1111.
- Bidirectional replication still asserted in test 1: all four pre-connection todos appear on both screens, plus a live write from Bob arriving at Alice afterwards.
- The link test now uses `/#invite=…` with no query parameter, and Bob unticks the box himself.
- 27 unit tests, `consent-screen` + `default-database-collaboration` (4 passed), prettier and eslint clean.

## Related

Testing the relay path and an invite on the *same* node is deliberately still not covered — filed as #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)