### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "simple-todo",
 	"private": true,
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"type": "module",
 	"exports": {
 		"./ConsentModal.svelte": "./src/lib/ConsentModal.svelte"


### PR DESCRIPTION
Version bump only.

**Minor, not patch.** Twelve commits since `v0.2.0`, three of them `feat:` adding user-visible functionality:

- **#126** — reach peers with an invite instead of a relay
- **#127** — `Scan Connect SDP` launcher next to the Relay Button, both transports on one node
- **#128** — choose relay-or-invite on the consent screen, and share invites as links

The other nine are fixes and test work (janitor sweep #113, rootfs repin #116, CRN failover #117, ws gater #105, SEO #112, and the E2E changes).

`0.2.1` would have understated it — new features move the minor under semver.